### PR TITLE
Change workflow run in ios

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - main
 
-
-
 jobs:
 
   build:

--- a/.github/workflows/ios_deploy.yml
+++ b/.github/workflows/ios_deploy.yml
@@ -1,16 +1,16 @@
 name: Publish to App Store Connect
 
-on: push
-#  workflow_dispatch:
-#  push:
-#    branches:
-#      - main
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     env:
       APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}

--- a/.github/workflows/ios_deploy.yml
+++ b/.github/workflows/ios_deploy.yml
@@ -1,10 +1,10 @@
 name: Publish to App Store Connect
 
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
+on: push
+#  workflow_dispatch:
+#  push:
+#    branches:
+#      - main
 
 
 
@@ -21,8 +21,6 @@ jobs:
       DIST_CERTIFICATE_PASSWORD: ${{ secrets.DIST_CERTIFICATE_PASSWORD }}
       DIST_PROFILE: ${{ secrets.DIST_PROFILE_BASE64 }}
 
-
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -35,14 +33,12 @@ jobs:
 
     - name: Retrieve the secret and decode it to file
       env:
-        FIREBASE_APP_ID_JSON_BASE64: ${{ secrets.FIREBASE_APP_ID_JSON_BASE64 }}
         FIREBASE_OPTIONS_BASE64: ${{ secrets.FIREBASE_OPTIONS_BASE64 }}
         GOOGLE_SERVICE_INFO_PLIST_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST_BASE64 }}
       run: |
         cd khelo
         echo $FIREBASE_OPTIONS_BASE64 | base64 --decode > lib/firebase_options.dart  
         echo $GOOGLE_SERVICE_INFO_PLIST_BASE64 | base64 --decode > ios/Runner/GoogleService-Info.plist
-        echo $FIREBASE_APP_ID_JSON_BASE64 | base64 --decode > ios/
 
     - name: Install Dependencies
       run: |

--- a/khelo/ios/Runner/Runner.entitlements
+++ b/khelo/ios/Runner/Runner.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>aps-environment</key>
-	<string>development</string>
-</dict>
+<dict/>
 </plist>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved the cleanliness of the Android build workflow by removing unnecessary empty lines.
- **Refactor**
	- Updated the iOS deployment workflow to trigger on push events only and refined the handling of secret decodings.
- **Refactor**
	- Removed the `aps-environment` key with the value `development` from the iOS entitlements file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->