### PR TITLE
Select team by default

### DIFF
--- a/khelo/lib/ui/app_route.dart
+++ b/khelo/lib/ui/app_route.dart
@@ -131,10 +131,12 @@ class AppRoute {
         ),
       );
 
-  static AppRoute addMatch({String? matchId}) => AppRoute(
+  static AppRoute addMatch({String? matchId, TeamModel? defaultTeam}) =>
+      AppRoute(
         pathAddMatch,
         builder: (_) => AddMatchScreen(
           matchId: matchId,
+          defaultTeam: defaultTeam,
         ),
       );
 

--- a/khelo/lib/ui/flow/matches/add_match/add_match_screen.dart
+++ b/khelo/lib/ui/flow/matches/add_match/add_match_screen.dart
@@ -1,3 +1,4 @@
+import 'package:data/api/team/team_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -34,8 +35,9 @@ import 'package:style/widgets/adaptive_outlined_tile.dart';
 
 class AddMatchScreen extends ConsumerStatefulWidget {
   final String? matchId;
+  final TeamModel? defaultTeam;
 
-  const AddMatchScreen({super.key, this.matchId});
+  const AddMatchScreen({super.key, this.matchId, this.defaultTeam});
 
   @override
   ConsumerState createState() => _AddMatchScreenState();
@@ -48,7 +50,7 @@ class _AddMatchScreenState extends ConsumerState<AddMatchScreen> {
   void initState() {
     super.initState();
     notifier = ref.read(addMatchViewStateProvider.notifier);
-    runPostFrame(() => notifier.setData(widget.matchId));
+    runPostFrame(() => notifier.setData(widget.matchId, widget.defaultTeam));
   }
 
   @override
@@ -163,14 +165,14 @@ class _AddMatchScreenState extends ConsumerState<AddMatchScreen> {
           context: context,
           controller: state.groundController,
           hintText: context.l10n.add_match_ground_title,
-          onChange: () => notifier.onTextChange(),
+          onChange: notifier.onTextChange,
         ),
         const SizedBox(height: 16),
         _inputField(
           context: context,
           controller: state.cityController,
           hintText: context.l10n.common_city_title,
-          onChange: () => notifier.onTextChange(),
+          onChange: notifier.onTextChange,
         ),
         _matchScheduleView(context, notifier, state),
         BallSelectionView(notifier: notifier, state: state),
@@ -409,7 +411,7 @@ class _AddMatchScreenState extends ConsumerState<AddMatchScreen> {
               context.l10n.common_delete_title.toLowerCase())),
           actions: [
             TextButton(
-              onPressed: () => context.pop(),
+              onPressed: context.pop,
               child: Text(
                 context.l10n.common_cancel_title,
                 style: TextStyle(color: context.colorScheme.textSecondary),

--- a/khelo/lib/ui/flow/matches/add_match/add_match_view_model.dart
+++ b/khelo/lib/ui/flow/matches/add_match/add_match_view_model.dart
@@ -37,10 +37,12 @@ class AddMatchViewNotifier extends StateNotifier<AddMatchViewState> {
           currentUserId: userId,
         ));
 
-  void setData(String? matchId) {
+  void setData(String? matchId, TeamModel? defaultTeam) {
     this.matchId = matchId;
     if (matchId != null) {
       getMatchById();
+    } else if (defaultTeam != null) {
+      onTeamSelect(defaultTeam, TeamType.a);
     } else {
       onTextChange();
     }

--- a/khelo/lib/ui/flow/team/detail/team_detail_screen.dart
+++ b/khelo/lib/ui/flow/team/detail/team_detail_screen.dart
@@ -77,7 +77,14 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
       children: [
         _teamProfileView(context, state),
         const SizedBox(height: 16),
-        _tabView(context),
+        _tabView(
+          context,
+          onAddButtonTap: () => AppRoute.addMatch(
+                  defaultTeam: (state.team?.players?.length ?? 0) >= 2
+                      ? state.team
+                      : null)
+              .push(context),
+        ),
         _content(context),
       ],
     );
@@ -120,7 +127,10 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
     );
   }
 
-  Widget _tabView(BuildContext context) {
+  Widget _tabView(
+    BuildContext context, {
+    required Function() onAddButtonTap,
+  }) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
       child: Row(
@@ -145,7 +155,7 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
           if (_selectedTab == 0) ...[
             const Spacer(),
             actionButton(context,
-                onPressed: () => AppRoute.addMatch().push(context),
+                onPressed: onAddButtonTap,
                 icon: Icon(
                   Icons.add,
                   color: context.colorScheme.textPrimary,


### PR DESCRIPTION
Select team by default when navigated from team detail screen (if team member is greater than **Two**)


![selectTeamByDefault](https://github.com/canopas/khelo/assets/122426509/f286fbdb-12b9-48ae-bced-77c81feedb83)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `defaultTeam` parameter to the `Add Match` screen for pre-selecting a team.
  - Introduced a new callback parameter `onAddButtonTap` in the Team Detail Screen's tab view for additional button logic handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->