### PR TITLE
change primary button height

### DIFF
--- a/khelo/lib/ui/flow/matches/add_match/add_match_view_model.dart
+++ b/khelo/lib/ui/flow/matches/add_match/add_match_view_model.dart
@@ -29,8 +29,8 @@ class AddMatchViewNotifier extends StateNotifier<AddMatchViewState> {
 
   AddMatchViewNotifier(this._matchService, String? userId)
       : super(AddMatchViewState(
-          totalOverController: TextEditingController(),
-          overPerBowlerController: TextEditingController(),
+          totalOverController: TextEditingController(text: "10"),
+          overPerBowlerController: TextEditingController(text: "2"),
           cityController: TextEditingController(),
           groundController: TextEditingController(),
           matchTime: DateTime.now(),

--- a/style/lib/button/primary_button.dart
+++ b/style/lib/button/primary_button.dart
@@ -51,8 +51,8 @@ class PrimaryButton extends StatelessWidget {
       enabled: tappable,
       child: Container(
         width: expanded ? double.infinity : null,
-        constraints: BoxConstraints(
-          minHeight: expanded ? 48 : 36,
+        constraints: const BoxConstraints(
+          minHeight: 48,
           minWidth: 88,
         ),
         padding: edgeInsets,


### PR DESCRIPTION
- Number of over by default = 10
- Over per bowler by default = 2
- Scoreboard sheet -> bottom sticky button height is less


Note: `Ball selection in add match is not much visible in dark mode` is remaining as designs required.

### Visual Evidence:
![buttonHeight](https://github.com/canopas/khelo/assets/122426509/dedd40c3-6691-4cc0-9494-154e73c8bac5)
![defaultValues](https://github.com/canopas/khelo/assets/122426509/fccdcc00-0866-421a-8475-97560dd94370)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Default values for overs set to "10" and overs per bowler set to "2" when adding a match, making the process quicker and more consistent.

- **Style**
  - Fixed the minimum height of the `PrimaryButton` to 48 for better consistency in appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->