### PR TITLE
Fix team detail not updating

### DIFF
--- a/khelo/lib/ui/flow/matches/add_match/add_match_screen.dart
+++ b/khelo/lib/ui/flow/matches/add_match/add_match_screen.dart
@@ -468,7 +468,7 @@ class _AddMatchScreenState extends ConsumerState<AddMatchScreen> {
     ref.listen(addMatchViewStateProvider.select((value) => value.pop),
         (previous, next) {
       if (next != null && next) {
-        context.pop();
+        context.pop(true);
       }
     });
   }

--- a/khelo/lib/ui/flow/team/add_team/add_team_screen.dart
+++ b/khelo/lib/ui/flow/team/add_team/add_team_screen.dart
@@ -296,7 +296,7 @@ class _AddTeamScreenState extends ConsumerState<AddTeamScreen> {
       addTeamStateProvider.select((value) => value.isPop),
       (previous, current) async {
         if (current && context.mounted) {
-          context.pop();
+          context.pop(current);
         }
       },
     );

--- a/khelo/lib/ui/flow/team/detail/team_detail_screen.dart
+++ b/khelo/lib/ui/flow/team/detail/team_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:data/api/user/user_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -70,7 +71,7 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
                         ? Icons.more_horiz_rounded
                         : Icons.more_vert_rounded,
                     color: context.colorScheme.textPrimary),
-                onPressed: () => _moreActionButton(context, state),
+                onPressed: () => _moreActionButton(context, notifier, state),
               ),
             ]
           : null,
@@ -185,32 +186,45 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
 
   void _moreActionButton(
     BuildContext context,
+    TeamDetailViewNotifier notifier,
     TeamDetailState state,
   ) async {
     return showActionBottomSheet(context: context, items: [
       BottomSheetAction(
         title: context.l10n.common_edit_team_title,
-        onTap: () {
+        onTap: () async {
           context.pop();
-          AppRoute.addTeam(team: state.team).push(context);
+          bool? isUpdated =
+              await AppRoute.addTeam(team: state.team).push<bool>(context);
+          if (isUpdated == true && context.mounted) {
+            notifier.loadTeamById();
+          }
         },
       ),
       BottomSheetAction(
         title: context.l10n.add_match_screen_title,
-        onTap: () {
+        onTap: () async {
           context.pop();
-          AppRoute.addMatch(
+          bool? isUpdated = await AppRoute.addMatch(
                   defaultTeam: (state.team?.players?.length ?? 0) >= 2
                       ? state.team
                       : null)
-              .push(context);
+              .push<bool>(context);
+          if (isUpdated == true && context.mounted) {
+            notifier.loadTeamById();
+          }
         },
       ),
       BottomSheetAction(
         title: context.l10n.team_list_add_members_title,
-        onTap: () {
+        onTap: () async {
           context.pop();
-          AppRoute.addTeamMember(team: state.team!).push(context);
+          List<UserModel>? memberList =
+              await AppRoute.addTeamMember(team: state.team!)
+                  .push<List<UserModel>>(context);
+          if (memberList != null && context.mounted) {
+            notifier.updateTeamMember(memberList);
+          }
         },
       ),
     ]);

--- a/khelo/lib/ui/flow/team/detail/team_detail_view_model.dart
+++ b/khelo/lib/ui/flow/team/detail/team_detail_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:data/api/match/match_model.dart';
 import 'package:data/api/team/team_model.dart';
+import 'package:data/api/user/user_models.dart';
 import 'package:data/service/match/match_service.dart';
 import 'package:data/service/team/team_service.dart';
 import 'package:data/storage/app_preferences.dart';
@@ -36,7 +37,7 @@ class TeamDetailViewNotifier extends StateNotifier<TeamDetailState> {
     }
 
     try {
-      state = state.copyWith(loading: true);
+      state = state.copyWith(loading: state.team == null);
 
       final team = await _teamService.getTeamById(teamId!);
       state = state.copyWith(team: team, loading: false);
@@ -53,7 +54,7 @@ class TeamDetailViewNotifier extends StateNotifier<TeamDetailState> {
       return;
     }
     try {
-      state = state.copyWith(loading: true);
+      state = state.copyWith(loading: state.matches == null);
       final matches = await _matchService
           .getMatchesByTeamId(state.team!.id ?? "INVALID ID");
       final teamStat = _calculateTeamStat(matches);
@@ -185,6 +186,12 @@ class TeamDetailViewNotifier extends StateNotifier<TeamDetailState> {
         }
       },
     );
+  }
+
+  void updateTeamMember(List<UserModel> members) {
+    state = state.copyWith(
+        team: state.team
+            ?.copyWith(players: [...state.team?.players ?? [], ...members]));
   }
 
   void onTabChange(int tab) {


### PR DESCRIPTION
Fix: add member doesn't reflect on team detail if done from more option button


### Note:
below changes are not included in this PR.
```
- In member tab, first cell should be add member option
- Merge screen title and top widget, place large three dot to top widget
```

### Visual Evidence

![addMember](https://github.com/canopas/khelo/assets/122426509/bcb997e9-2f22-4d80-82f4-bbf00ac788be)
![editTeam](https://github.com/canopas/khelo/assets/122426509/a4844020-16ea-4471-9352-f35c91e4fd6d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved screen navigation by updating `context.pop()` calls in the Add Match and Add Team screens to ensure proper state handling.

- **New Features**
  - Enhanced team detail functionality with improved loading logic and team member management in the Team Detail View.

- **Refactor**
  - Updated `moreActionButton` method in the Team Detail screen to include additional parameters and asynchronous operations for better functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->