### PR TITLE
Redesign team detail

### DIFF
--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -234,6 +234,7 @@
   "team_detail_empty_match_title": "Team hasn't compete with opponent till now.",
   "team_detail_stat_tab_title": "Stat",
   "team_detail_empty_stat_title": "Team's analysis will be shown here based on it's previous matches.",
+  "team_detail_add_member_title": "Add member",
   "team_detail_won_title": "Won({win})",
   "@team_detail_won_title": {
     "description": "Won({win})",

--- a/khelo/lib/components/action_bottom_sheet.dart
+++ b/khelo/lib/components/action_bottom_sheet.dart
@@ -80,7 +80,7 @@ class BottomSheetAction extends StatelessWidget {
             Expanded(
               child: Text(
                 title,
-                style: AppTextStyle.body1
+                style: AppTextStyle.subtitle2
                     .copyWith(color: context.colorScheme.textPrimary),
               ),
             ),

--- a/khelo/lib/components/app_page.dart
+++ b/khelo/lib/components/app_page.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:style/text/app_text_style.dart';
+import 'package:style/widgets/custom_cupertino_navigation_bar.dart';
 
 class AppPage extends StatelessWidget {
   final String? title;
@@ -11,9 +11,10 @@ class AppPage extends StatelessWidget {
   final Widget? leading;
   final Widget? floatingActionButton;
   final Widget? body;
+  final EdgeInsets? padding;
   final bool automaticallyImplyLeading;
   final bool resizeToAvoidBottomInset;
-  final Color? backgroundColor;
+  final Color? appBarBackgroundColor;
 
   const AppPage({
     super.key,
@@ -22,10 +23,11 @@ class AppPage extends StatelessWidget {
     this.actions,
     this.leading,
     this.body,
+    this.padding,
     this.automaticallyImplyLeading = true,
     this.resizeToAvoidBottomInset = true,
     this.floatingActionButton,
-    this.backgroundColor,
+    this.appBarBackgroundColor,
   });
 
   @override
@@ -38,16 +40,16 @@ class AppPage extends StatelessWidget {
   }
 
   Widget _cupertino(BuildContext context) => CupertinoPageScaffold(
-        backgroundColor: backgroundColor,
         resizeToAvoidBottomInset: resizeToAvoidBottomInset,
         navigationBar: (title == null && titleWidget == null) &&
                 actions == null &&
                 leading == null
             ? null
-            : CupertinoNavigationBar(
+            : CustomCupertinoNavigationBar(
                 leading: leading,
+                padding: padding ?? const EdgeInsets.symmetric(horizontal: 8),
+                backgroundColor: appBarBackgroundColor,
                 middle: titleWidget ?? _title(),
-                border: null,
                 trailing: actions == null
                     ? null
                     : actions!.length == 1
@@ -76,14 +78,18 @@ class AppPage extends StatelessWidget {
       );
 
   Widget _material() => Scaffold(
-        backgroundColor: backgroundColor,
         resizeToAvoidBottomInset: resizeToAvoidBottomInset,
         appBar: (title == null && titleWidget == null) &&
                 actions == null &&
                 leading == null
             ? null
             : AppBar(
-                title: titleWidget ?? _title(),
+                backgroundColor: appBarBackgroundColor,
+                toolbarHeight: kToolbarHeight + (padding?.vertical ?? 0),
+                title: Padding(
+                    padding:
+                        padding ?? const EdgeInsets.symmetric(horizontal: 8),
+                    child: titleWidget ?? _title()),
                 actions: actions,
                 leading: leading,
                 automaticallyImplyLeading: automaticallyImplyLeading,

--- a/khelo/lib/ui/flow/sign_in/phone_verification/phone_verification_screen.dart
+++ b/khelo/lib/ui/flow/sign_in/phone_verification/phone_verification_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:khelo/components/app_page.dart';
@@ -57,12 +56,11 @@ class _PhoneVerificationScreenState
     _observeActionError(context, ref);
     _observeVerificationComplete();
 
-    return PopScope(
-      canPop: false,
-      child: IntroGradientBackground(
-        child: AppPage(
-          backgroundColor: Colors.transparent,
-          body: Builder(builder: (context) {
+    return AppPage(
+      body: IntroGradientBackground(
+        child: PopScope(
+          canPop: false,
+          child: Builder(builder: (context) {
             return Padding(
               padding: context.mediaQueryPadding +
                   const EdgeInsets.symmetric(horizontal: 16.0),

--- a/khelo/lib/ui/flow/sign_in/sign_in_with_phone/sign_in_with_phone_screen.dart
+++ b/khelo/lib/ui/flow/sign_in/sign_in_with_phone/sign_in_with_phone_screen.dart
@@ -1,6 +1,5 @@
 import 'package:data/storage/app_preferences.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:khelo/components/app_page.dart';
@@ -27,10 +26,9 @@ class SignInWithPhoneScreen extends ConsumerWidget {
     _observeOtp(context: context, ref: ref);
     _observeSignInSuccess(context: context, ref: ref);
 
-    return IntroGradientBackground(
-      child: AppPage(
-        backgroundColor: Colors.transparent,
-        body: PopScope(
+    return AppPage(
+      body: IntroGradientBackground(
+        child: PopScope(
           canPop: false,
           child: Builder(builder: (context) {
             return Padding(

--- a/khelo/lib/ui/flow/team/detail/components/team_detail_match_content.dart
+++ b/khelo/lib/ui/flow/team/detail/components/team_detail_match_content.dart
@@ -17,7 +17,7 @@ class TeamDetailMatchContent extends ConsumerWidget {
 
     if (state.matches != null && state.matches!.isNotEmpty) {
       return ListView.separated(
-        padding: const EdgeInsets.all(16) + context.mediaQueryPadding,
+        padding: const EdgeInsets.all(16),
         itemCount: state.matches?.length ?? 0,
         itemBuilder: (context, index) {
           final match = state.matches![index];

--- a/khelo/lib/ui/flow/team/detail/components/team_detail_member_content.dart
+++ b/khelo/lib/ui/flow/team/detail/components/team_detail_member_content.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:khelo/components/user_detail_cell.dart';
 import 'package:khelo/domain/extensions/context_extensions.dart';
+import 'package:khelo/ui/app_route.dart';
 import 'package:khelo/ui/flow/team/detail/team_detail_view_model.dart';
+import 'package:style/animations/on_tap_scale.dart';
 import 'package:style/extensions/context_extensions.dart';
 import 'package:style/text/app_text_style.dart';
 
@@ -18,10 +20,17 @@ class TeamDetailMemberContent extends ConsumerWidget {
     if (state.team?.players != null &&
         state.team?.players?.isNotEmpty == true) {
       return ListView.separated(
-        padding: context.mediaQueryPadding + const EdgeInsets.all(16),
-        itemCount: state.team!.players!.length,
+        padding: const EdgeInsets.all(16),
+        itemCount: state.team!.players!.length + 1,
         itemBuilder: (context, index) {
-          final member = state.team!.players![index];
+          if (index == 0) {
+            return _addMemberButton(
+              context,
+              onTap: () =>
+                  AppRoute.addTeamMember(team: state.team!).push(context),
+            );
+          }
+          final member = state.team!.players![index - 1];
           return UserDetailCell(
               user: member,
               onTap: () => UserDetailSheet.show(context, member),
@@ -42,5 +51,34 @@ class TeamDetailMemberContent extends ConsumerWidget {
         ),
       );
     }
+  }
+
+  Widget _addMemberButton(BuildContext context, {required Function() onTap}) {
+    return OnTapScale(
+      onTap: onTap,
+      child: Row(
+        children: [
+          Container(
+            height: 40,
+            width: 40,
+            decoration: BoxDecoration(
+              color: context.colorScheme.containerLow,
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              Icons.add,
+              size: 24,
+              color: context.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Text(
+            context.l10n.team_detail_add_member_title,
+            style: AppTextStyle.subtitle2
+                .copyWith(color: context.colorScheme.primary),
+          )
+        ],
+      ),
+    );
   }
 }

--- a/khelo/lib/ui/flow/team/detail/components/team_detail_member_content.dart
+++ b/khelo/lib/ui/flow/team/detail/components/team_detail_member_content.dart
@@ -58,13 +58,9 @@ class TeamDetailMemberContent extends ConsumerWidget {
       onTap: onTap,
       child: Row(
         children: [
-          Container(
-            height: 40,
-            width: 40,
-            decoration: BoxDecoration(
-              color: context.colorScheme.containerLow,
-              shape: BoxShape.circle,
-            ),
+          CircleAvatar(
+            radius: 20,
+            backgroundColor: context.colorScheme.containerLow,
             child: Icon(
               Icons.add,
               size: 24,

--- a/khelo/lib/ui/flow/team/detail/team_detail_screen.dart
+++ b/khelo/lib/ui/flow/team/detail/team_detail_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:data/api/user/user_models.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -61,7 +61,17 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
   Widget build(BuildContext context) {
     final state = ref.watch(teamDetailStateProvider);
     return AppPage(
-      title: state.team?.name ?? context.l10n.team_detail_screen_title,
+      automaticallyImplyLeading: false,
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      appBarBackgroundColor: context.colorScheme.containerLow,
+      titleWidget: _teamProfileView(context, state),
+      leading: actionButton(context,
+          onPressed: context.pop,
+          icon: Icon(
+            CupertinoIcons.chevron_back,
+            size: 24,
+            color: context.colorScheme.textPrimary,
+          )),
       actions: (state.currentUserId == state.team?.created_by)
           ? [
               actionButton(
@@ -81,6 +91,35 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
     );
   }
 
+  Widget _teamProfileView(BuildContext context, TeamDetailState state) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        // profile view
+        ImageAvatar(
+          initial: state.team?.name[0].toUpperCase() ?? "?",
+          imageUrl: state.team?.profile_img_url,
+          size: 48,
+        ),
+        const SizedBox(width: 16),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(state.team?.name ?? "",
+                style: AppTextStyle.subtitle1
+                    .copyWith(color: context.colorScheme.textPrimary)),
+            const SizedBox(height: 4),
+            Text(
+                (state.team?.created_at ?? DateTime.now())
+                    .format(context, DateFormatType.dayMonthYear),
+                style: AppTextStyle.body2
+                    .copyWith(color: context.colorScheme.textSecondary)),
+          ],
+        ),
+      ],
+    );
+  }
+
   Widget _body(BuildContext context, TeamDetailState state) {
     if (state.loading) {
       return const Center(child: AppProgressIndicator());
@@ -93,52 +132,14 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
     }
 
     return Padding(
-      padding:
-          context.mediaQueryPadding + const EdgeInsets.symmetric(vertical: 16),
+      padding: context.mediaQueryPadding,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _teamProfileView(context, state),
           const SizedBox(height: 16),
           _tabView(context),
+          const SizedBox(height: 16),
           _content(context),
-        ],
-      ),
-    );
-  }
-
-  Widget _teamProfileView(BuildContext context, TeamDetailState state) {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      margin: const EdgeInsets.symmetric(horizontal: 16),
-      decoration: BoxDecoration(
-        color: context.colorScheme.containerNormal,
-        borderRadius: BorderRadius.circular(16),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: [
-          // profile view
-          ImageAvatar(
-            initial: state.team?.name[0].toUpperCase() ?? "?",
-            imageUrl: state.team?.profile_img_url,
-            size: 80,
-          ),
-          const SizedBox(width: 16),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(state.team?.name ?? "",
-                  style: AppTextStyle.subtitle1
-                      .copyWith(color: context.colorScheme.textPrimary)),
-              const SizedBox(height: 4),
-              Text(
-                  (state.team?.created_at ?? DateTime.now())
-                      .format(context, DateFormatType.dayMonthYear),
-                  style: AppTextStyle.body2
-                      .copyWith(color: context.colorScheme.textSecondary)),
-            ],
-          ),
         ],
       ),
     );
@@ -189,45 +190,36 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
     TeamDetailViewNotifier notifier,
     TeamDetailState state,
   ) async {
-    return showActionBottomSheet(context: context, items: [
-      BottomSheetAction(
-        title: context.l10n.common_edit_team_title,
-        onTap: () async {
-          context.pop();
-          bool? isUpdated =
-              await AppRoute.addTeam(team: state.team).push<bool>(context);
-          if (isUpdated == true && context.mounted) {
-            notifier.loadTeamById();
-          }
-        },
-      ),
-      BottomSheetAction(
-        title: context.l10n.add_match_screen_title,
-        onTap: () async {
-          context.pop();
-          bool? isUpdated = await AppRoute.addMatch(
-                  defaultTeam: (state.team?.players?.length ?? 0) >= 2
-                      ? state.team
-                      : null)
-              .push<bool>(context);
-          if (isUpdated == true && context.mounted) {
-            notifier.loadTeamById();
-          }
-        },
-      ),
-      BottomSheetAction(
-        title: context.l10n.team_list_add_members_title,
-        onTap: () async {
-          context.pop();
-          List<UserModel>? memberList =
-              await AppRoute.addTeamMember(team: state.team!)
-                  .push<List<UserModel>>(context);
-          if (memberList != null && context.mounted) {
-            notifier.updateTeamMember(memberList);
-          }
-        },
-      ),
-    ]);
+    return showActionBottomSheet(
+        context: context,
+        showDragHandle: true,
+        items: [
+          BottomSheetAction(
+            title: context.l10n.common_edit_team_title,
+            onTap: () async {
+              context.pop();
+              bool? isUpdated =
+                  await AppRoute.addTeam(team: state.team).push<bool>(context);
+              if (isUpdated == true && context.mounted) {
+                notifier.loadTeamById();
+              }
+            },
+          ),
+          BottomSheetAction(
+            title: context.l10n.add_match_screen_title,
+            onTap: () async {
+              context.pop();
+              bool? isUpdated = await AppRoute.addMatch(
+                      defaultTeam: (state.team?.players?.length ?? 0) >= 2
+                          ? state.team
+                          : null)
+                  .push<bool>(context);
+              if (isUpdated == true && context.mounted) {
+                notifier.loadTeamById();
+              }
+            },
+          ),
+        ]);
   }
 
   @override

--- a/khelo/lib/ui/flow/team/team_list_screen.dart
+++ b/khelo/lib/ui/flow/team/team_list_screen.dart
@@ -171,22 +171,25 @@ class _TeamListScreenState extends ConsumerState<TeamListScreen>
     BuildContext context,
     TeamModel team,
   ) async {
-    return await showActionBottomSheet(context: context, items: [
-      BottomSheetAction(
-        title: context.l10n.team_list_add_members_title,
-        onTap: () {
-          context.pop();
-          AppRoute.addTeamMember(team: team).push(context);
-        },
-      ),
-      BottomSheetAction(
-        title: context.l10n.common_edit_team_title,
-        onTap: () {
-          context.pop();
-          AppRoute.addTeam(team: team).push(context);
-        },
-      ),
-    ]);
+    return await showActionBottomSheet(
+        context: context,
+        showDragHandle: true,
+        items: [
+          BottomSheetAction(
+            title: context.l10n.team_list_add_members_title,
+            onTap: () {
+              context.pop();
+              AppRoute.addTeamMember(team: team).push(context);
+            },
+          ),
+          BottomSheetAction(
+            title: context.l10n.common_edit_team_title,
+            onTap: () {
+              context.pop();
+              AppRoute.addTeam(team: team).push(context);
+            },
+          ),
+        ]);
   }
 
   void _filterActionSheet(

--- a/style/lib/widgets/custom_cupertino_navigation_bar.dart
+++ b/style/lib/widgets/custom_cupertino_navigation_bar.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:style/extensions/context_extensions.dart';
+
+class CustomCupertinoNavigationBar extends StatelessWidget
+    implements ObstructingPreferredSizeWidget {
+  final Widget? leading;
+  final Widget? middle;
+  final Widget? trailing;
+  final bool automaticallyImplyLeading;
+  final String? previousPageTitle;
+  final Color? backgroundColor;
+  final EdgeInsets padding;
+
+  const CustomCupertinoNavigationBar({
+    Key? key,
+    this.leading,
+    this.middle,
+    this.trailing,
+    this.automaticallyImplyLeading = true,
+    this.previousPageTitle,
+    this.backgroundColor,
+    this.padding = const EdgeInsets.symmetric(horizontal: 16),
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    SystemChrome.setSystemUIOverlayStyle(
+      context.brightness == Brightness.dark
+          ? SystemUiOverlayStyle.light
+          : SystemUiOverlayStyle.dark,
+    );
+
+    return Container(
+      padding: padding,
+      decoration: BoxDecoration(
+        color: backgroundColor ?? CupertinoTheme.of(context).barBackgroundColor,
+        border: null,
+      ),
+      child: SafeArea(
+          bottom: false,
+          child: SizedBox(
+            height: kMinInteractiveDimension,
+            child: NavigationToolbar(
+              leading: leadingWidget(context),
+              middle: middleWidget(context),
+              trailing: trailingWidget(),
+              middleSpacing: 6.0,
+            ),
+          )),
+    );
+  }
+
+  Widget leadingWidget(BuildContext context) {
+    if (automaticallyImplyLeading && Navigator.of(context).canPop()) {
+      return CupertinoNavigationBarBackButton(
+        previousPageTitle: previousPageTitle,
+        onPressed: () => Navigator.maybePop(context),
+      );
+    }
+    if (leading != null && !automaticallyImplyLeading) return leading!;
+    return const SizedBox();
+  }
+
+  Widget middleWidget(BuildContext context) {
+    return DefaultTextStyle(
+      style: CupertinoTheme.of(context).textTheme.navTitleTextStyle,
+      child: middle ?? const SizedBox(), // Ensure middle is never null
+    );
+  }
+
+  Widget trailingWidget() {
+    return (trailing != null)
+        ? Padding(
+            padding: const EdgeInsets.only(left: 8.0),
+            child: trailing!,
+          )
+        : const SizedBox();
+  }
+
+  @override
+  Size get preferredSize =>
+      Size.fromHeight(kMinInteractiveDimension + padding.vertical);
+
+  @override
+  bool shouldFullyObstruct(BuildContext context) => true;
+}

--- a/style/lib/widgets/custom_cupertino_navigation_bar.dart
+++ b/style/lib/widgets/custom_cupertino_navigation_bar.dart
@@ -66,7 +66,7 @@ class CustomCupertinoNavigationBar extends StatelessWidget
   Widget middleWidget(BuildContext context) {
     return DefaultTextStyle(
       style: CupertinoTheme.of(context).textTheme.navTitleTextStyle,
-      child: middle ?? const SizedBox(), // Ensure middle is never null
+      child: middle ?? const SizedBox(),
     );
   }
 


### PR DESCRIPTION
Redesign team details screen

[android_team_detail.webm](https://github.com/canopas/khelo/assets/122426509/7d5ac1fe-f09e-4d26-a865-30af16adad1d)

![ios_team_detail](https://github.com/canopas/khelo/assets/122426509/e8cfce09-d0dc-4f94-b072-7e23c20bbcb9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new localization for "Add member" in the app.
  - Introduced a customizable `CustomCupertinoNavigationBar` for enhanced navigation bar styling.

- **UI/UX Improvements**
  - Updated text style in bottom sheet actions for better readability.
  - Enhanced the `AppPage` class with new padding and renamed background color properties for improved layout customization.
  - Improved widget hierarchy and layout in the phone verification and sign-in screens.
  - Refined team detail screens with updated AppBar elements, Cupertino icons, and reorganized profile view content.
  - Added a drag handle to the action bottom sheet in team list screen for better user interaction.

- **Functional Enhancements**
  - Added a button to facilitate adding team members in team detail member content.

- **Code Maintenance**
  - Removed unused import statements for cleaner codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->