### PR TITLE
Show drag handle in all sheets

### DIFF
--- a/khelo/lib/components/action_bottom_sheet.dart
+++ b/khelo/lib/components/action_bottom_sheet.dart
@@ -9,7 +9,7 @@ Future<T?> showActionBottomSheet<T>({
   required BuildContext context,
   required List<BottomSheetAction> items,
   bool useRootNavigator = true,
-  bool? showDragHandle,
+  bool showDragHandle = true,
 }) async {
   HapticFeedback.mediumImpact();
   return await showModalBottomSheet<T>(

--- a/khelo/lib/ui/flow/settings/edit_profile/edit_profile_screen.dart
+++ b/khelo/lib/ui/flow/settings/edit_profile/edit_profile_screen.dart
@@ -95,8 +95,7 @@ class EditProfileScreen extends ConsumerWidget {
                       onConfirm: notifier.onDeleteTap),
                 ),
                 Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 8.0, vertical: 16),
+                  padding: const EdgeInsets.all(16),
                   child: Text(
                     context.l10n.edit_profile_delete_account_description_text,
                     style: AppTextStyle.body2.copyWith(

--- a/khelo/lib/ui/flow/team/detail/team_detail_screen.dart
+++ b/khelo/lib/ui/flow/team/detail/team_detail_screen.dart
@@ -184,7 +184,6 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
   ) async {
     return showActionBottomSheet(
         context: context,
-        showDragHandle: true,
         items: [
           BottomSheetAction(
             title: context.l10n.common_edit_team_title,

--- a/khelo/lib/ui/flow/team/team_list_screen.dart
+++ b/khelo/lib/ui/flow/team/team_list_screen.dart
@@ -147,7 +147,6 @@ class _TeamListScreenState extends ConsumerState<TeamListScreen>
   ) async {
     return await showActionBottomSheet(
         context: context,
-        showDragHandle: true,
         items: [
           BottomSheetAction(
             title: context.l10n.team_list_add_members_title,
@@ -170,8 +169,6 @@ class _TeamListScreenState extends ConsumerState<TeamListScreen>
       BuildContext context, TeamFilterOption selectedFilter) async {
     return await showActionBottomSheet(
         context: context,
-        useRootNavigator: true,
-        showDragHandle: true,
         items: TeamFilterOption.values
             .map((option) => BottomSheetAction(
                 title: option.getString(context),

--- a/style/lib/text/app_text_style.dart
+++ b/style/lib/text/app_text_style.dart
@@ -75,7 +75,7 @@ class AppTextStyle {
 
   static const TextStyle body2 = TextStyle(
     fontFamily: poppinsFontFamily,
-    fontWeight: FontWeight.normal,
+    fontWeight: FontWeight.w500,
     fontSize: 14,
     height: 1.5,
     package: 'style',


### PR DESCRIPTION
Show drag handle in all sheets
Change body 2 font weight

![dragHandleInSheet](https://github.com/canopas/khelo/assets/122426509/c92b1c65-d49f-4a22-9e25-d907a451dc94)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Default drag handle enabled for action bottom sheets.

- **Style**
    - Improved text weight in `body2` style for better readability.

- **Bug Fixes**
    - Consistent padding in edit profile screen for a uniform layout.
    - Removed unnecessary parameters in team detail and team list screens for streamlined action bottom sheets.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->