### PR TITLE
Match detail bottom padding

### DIFF
--- a/khelo/lib/ui/flow/matches/match_detail/components/match_detail_commentary_view.dart
+++ b/khelo/lib/ui/flow/matches/match_detail/components/match_detail_commentary_view.dart
@@ -41,7 +41,8 @@ class MatchDetailCommentaryView extends ConsumerWidget {
 
     return (state.overList.isNotEmpty)
         ? ListView(
-            padding: context.mediaQueryPadding,
+            padding:
+                context.mediaQueryPadding + const EdgeInsets.only(bottom: 24),
             children: _buildCommentaryList(context, state),
           )
         : EmptyScreen(

--- a/khelo/lib/ui/flow/matches/match_detail/components/match_detail_highlight_view.dart
+++ b/khelo/lib/ui/flow/matches/match_detail/components/match_detail_highlight_view.dart
@@ -133,6 +133,7 @@ class MatchDetailHighlightView extends ConsumerWidget {
       );
     } else {
       return ListView.separated(
+        padding: const EdgeInsets.only(bottom: 24),
         itemCount: highlight.length,
         separatorBuilder: (context, index) =>
             Divider(color: context.colorScheme.outline, height: 32),

--- a/khelo/lib/ui/flow/matches/match_detail/components/match_detail_overs_view.dart
+++ b/khelo/lib/ui/flow/matches/match_detail/components/match_detail_overs_view.dart
@@ -38,7 +38,7 @@ class MatchDetailOversView extends ConsumerWidget {
 
     return (state.overList.isNotEmpty)
         ? ListView(
-            padding: context.mediaQueryPadding,
+            padding: context.mediaQueryPadding+const EdgeInsets.only(bottom: 24),
             children: [
               const Padding(
                 padding: EdgeInsets.symmetric(horizontal: 16.0),

--- a/khelo/lib/ui/flow/matches/match_detail/components/match_detail_scorecard_view.dart
+++ b/khelo/lib/ui/flow/matches/match_detail/components/match_detail_scorecard_view.dart
@@ -61,8 +61,8 @@ class MatchDetailScorecardView extends ConsumerWidget {
         Expanded(
           child: ListView.separated(
             padding: context.mediaQueryPadding +
-                EdgeInsets.symmetric(
-                    vertical: state.match?.matchResult == null ? 16 : 0),
+                EdgeInsets.only(
+                    top: state.match?.matchResult == null ? 16 : 0, bottom: 16),
             itemCount: groupOversByInning(state.overList).length,
             itemBuilder: (context, index) {
               final inningOvers = groupOversByInning(state.overList)[index];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced visual layout across various views in the Match Detail section by adding or adjusting bottom padding.
		- **MatchDetailCommentaryView:** Added bottom padding of 24 units.
		- **MatchDetailHighlightView:** Added bottom padding of 24 units to the `ListView.separated` widget.
		- **MatchDetailOversView:** Added bottom padding of 24 units.
		- **MatchDetailScorecardView:** Adjusted padding to improve spacing based on match results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->