### PR TITLE
Fix edit team was not reflecting on member add

### DIFF
--- a/khelo/android/app/build.gradle
+++ b/khelo/android/app/build.gradle
@@ -26,7 +26,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.canopas.khelo"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -47,7 +47,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 23
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         android.applicationVariants.all { variant ->

--- a/khelo/lib/ui/flow/team/add_team/add_team_screen.dart
+++ b/khelo/lib/ui/flow/team/add_team/add_team_screen.dart
@@ -1,4 +1,5 @@
 import 'package:data/api/team/team_model.dart';
+import 'package:data/api/user/user_models.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -152,9 +153,15 @@ class _AddTeamScreenState extends ConsumerState<AddTeamScreen> {
                   const SizedBox(width: 16),
                   actionButton(
                     context,
-                    onPressed: () =>
-                        AppRoute.addTeamMember(team: widget.editTeam!)
-                            .push(context),
+                    onPressed: () async {
+                      final members = await AppRoute.addTeamMember(
+                              team: widget.editTeam!
+                                  .copyWith(players: state.teamMembers))
+                          .push<List<UserModel>>(context);
+                      if (context.mounted && (members ?? []).isNotEmpty) {
+                        notifier.updatePlayersList(members!);
+                      }
+                    },
                     icon: Icon(
                       CupertinoIcons.add,
                       color: context.colorScheme.textPrimary,

--- a/khelo/lib/ui/flow/team/add_team/add_team_view_model.dart
+++ b/khelo/lib/ui/flow/team/add_team/add_team_view_model.dart
@@ -49,7 +49,7 @@ class AddTeamViewNotifier extends StateNotifier<AddTeamState> {
     state = state.copyWith(currentUser: user);
   }
 
-  Future<void> updatePlayersList(List<UserModel> players) async {
+  void updatePlayersList(List<UserModel> players) {
     if (state.editTeam == null) {
       return;
     }


### PR DESCRIPTION
Fix: edit team not reflecting on member add 
![editTeamReflect](https://github.com/canopas/khelo/assets/122426509/906699b5-f6c6-4011-a54e-141364041140)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved asynchronous handling for adding team members in the add team screen, ensuring a smoother and more responsive user experience.

- **Chores**
  - Updated Android build configurations to use hardcoded SDK versions for better compatibility and future-proofing.
  
- **Refactor**
  - Modified the `AddTeamViewNotifier` to streamline the method for updating the player list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->