### PR TITLE
Add substitute in match

### DIFF
--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -229,11 +229,15 @@
   "select_squad_rest_of_team_title": "Rest of The Team",
   "select_squad_empty_squad_text": "Select squad via adding it from team members list.",
   "select_squad_empty_team_member_text": "No team member added in this team, try to add people you know as a team member.",
+
   "add_toss_detail_screen_title": "Add Toss Detail",
   "add_toss_detail_who_won_toss_text": "Who won the toss?",
   "add_toss_detail_winner_elected_to_text": "Toss-winner elected to - ?",
   "add_toss_detail_bat_text": "Batting",
   "add_toss_detail_bowl_text": "Bowling",
+
+  "add_substitute_search_substitute_title":"Who’s ready to step in?",
+  "add_substitute_search_substitute_description":"Search and assign a substitute fielder to maintain your fielding edge.",
 
   "team_detail_screen_title": "Team Detail",
   "team_detail_member_tab_title": "Member",
@@ -582,6 +586,7 @@
   "score_board_undo_last_ball_title": "Undo Last Ball",
   "score_board_undo_last_ball_description_text": "are you sure you want to undo last ball?",
   "score_board_pause_scoring_title": "Pause Scoring",
+  "score_board_add_substitute_title": "Add Substitute",
   "score_board_penalty_run_title": "Penalty Run",
   "score_board_awarded_to_text": "Awarded to - ?",
   "score_board_continue_with_injured_player_title": "Continue With Injured Player",

--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -587,6 +587,7 @@
   "score_board_undo_last_ball_description_text": "are you sure you want to undo last ball?",
   "score_board_pause_scoring_title": "Pause Scoring",
   "score_board_add_substitute_title": "Add Substitute",
+  "score_board_substitute_title": "Substitute",
   "score_board_penalty_run_title": "Penalty Run",
   "score_board_awarded_to_text": "Awarded to - ?",
   "score_board_continue_with_injured_player_title": "Continue With Injured Player",

--- a/khelo/lib/ui/flow/matches/add_match/select_squad/components/user_detail_sheet.dart
+++ b/khelo/lib/ui/flow/matches/add_match/select_squad/components/user_detail_sheet.dart
@@ -94,11 +94,10 @@ class UserDetailSheet extends StatelessWidget {
               padding: const EdgeInsets.all(16.0),
               child: PrimaryButton(
                 actionButtonTitle!,
+                enabled: onButtonTap != null,
                 onPressed: () {
                   context.pop();
-                  if (onButtonTap != null) {
-                    onButtonTap!();
-                  }
+                  onButtonTap?.call();
                 },
               ),
             )

--- a/khelo/lib/ui/flow/matches/match_detail/components/match_detail_squad_view.dart
+++ b/khelo/lib/ui/flow/matches/match_detail/components/match_detail_squad_view.dart
@@ -1,3 +1,4 @@
+import 'package:data/api/match/match_model.dart';
 import 'package:data/api/user/user_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -41,13 +42,22 @@ class MatchDetailSquadView extends ConsumerWidget {
   Widget _listView(BuildContext context, MatchDetailTabState state) {
     final firstTeam = state.match!.teams.firstOrNull;
     final secondTeam = state.match!.teams.elementAtOrNull(1);
+
     final firstTeamSquad = firstTeam?.squad
-            .where((element) => element.player.isActive)
+            .where((element) =>
+                element.player.isActive &&
+                !element.performance.any(
+                  (element) => element.status == PlayerStatus.substitute,
+                ))
             .map((e) => e.player)
             .toList() ??
         [];
     final secondTeamSquad = secondTeam?.squad
-            .where((element) => element.player.isActive)
+            .where((element) =>
+                element.player.isActive &&
+                !element.performance.any(
+                  (element) => element.status == PlayerStatus.substitute,
+                ))
             .map((e) => e.player)
             .toList() ??
         [];
@@ -58,7 +68,6 @@ class MatchDetailSquadView extends ConsumerWidget {
                 element.isActive)
             .toList() ??
         [];
-
     final secondTeamBench = secondTeam?.team.players
             ?.where((element) =>
                 !secondTeamSquad.map((e) => e.id).contains(element.id) &&
@@ -79,10 +88,12 @@ class MatchDetailSquadView extends ConsumerWidget {
             firstTeamCaptainId: state.match!.teams.firstOrNull?.captain_id,
             secondTeamCaptainId:
                 state.match!.teams.elementAtOrNull(1)?.captain_id),
-        ..._buildTeamList(context,
-            title: context.l10n.match_squad_bench_title,
-            firstTeamPlayers: firstTeamBench,
-            secondPlayers: secondTeamBench)
+        ..._buildTeamList(
+          context,
+          title: context.l10n.match_squad_bench_title,
+          firstTeamPlayers: firstTeamBench,
+          secondPlayers: secondTeamBench,
+        )
       ],
     );
   }

--- a/khelo/lib/ui/flow/score_board/add_substitute/add_substitute_sheet.dart
+++ b/khelo/lib/ui/flow/score_board/add_substitute/add_substitute_sheet.dart
@@ -82,14 +82,13 @@ class _AddSubstituteSheetState extends ConsumerState<AddSubstituteSheet> {
 
     return BottomSheetWrapper(
       contentBottomSpacing: 0,
+      height: context.mediaQuerySize.height * 0.8,
       content: _content(context, state),
       action: [
         PrimaryButton(
           context.l10n.common_select_title,
           enabled: selectedPlayer != null,
-          onPressed: () {
-            context.pop(selectedPlayer);
-          },
+          onPressed: () => context.pop(selectedPlayer),
         ),
       ],
     );
@@ -103,24 +102,20 @@ class _AddSubstituteSheetState extends ConsumerState<AddSubstituteSheet> {
       );
     }
 
-    return SizedBox(
-      height: context.mediaQuerySize.height * 0.8,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            context.l10n.score_board_add_substitute_title,
-            style: AppTextStyle.header3
-                .copyWith(color: context.colorScheme.textPrimary),
-          ),
-          const SizedBox(height: 16),
-          _benchPlayerView(context, state.nonPlayingPlayers),
-          const SizedBox(height: 16),
-          _searchTextField(context, notifier, state),
-          const SizedBox(height: 24),
-          _searchResultView(context, notifier, state),
-        ],
-      ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          context.l10n.score_board_add_substitute_title,
+          style: AppTextStyle.header3
+              .copyWith(color: context.colorScheme.textPrimary),
+        ),
+        const SizedBox(height: 16),
+        _benchPlayerView(context, state.nonPlayingPlayers),
+        _searchTextField(context, notifier, state),
+        const SizedBox(height: 24),
+        _searchResultView(context, notifier, state),
+      ],
     );
   }
 
@@ -130,7 +125,7 @@ class _AddSubstituteSheetState extends ConsumerState<AddSubstituteSheet> {
       child: Row(
         children: bench.map((player) {
           return Padding(
-            padding: const EdgeInsets.only(right: 16.0),
+            padding: const EdgeInsets.only(right: 16, bottom: 16),
             child: UserCellView(
               title: player.name ?? context.l10n.common_anonymous_title,
               imageUrl: player.profile_img_url,

--- a/khelo/lib/ui/flow/score_board/add_substitute/add_substitute_sheet.dart
+++ b/khelo/lib/ui/flow/score_board/add_substitute/add_substitute_sheet.dart
@@ -1,0 +1,225 @@
+import 'package:data/api/user/user_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:khelo/components/empty_screen.dart';
+import 'package:khelo/components/error_screen.dart';
+import 'package:khelo/components/user_detail_cell.dart';
+import 'package:khelo/domain/extensions/context_extensions.dart';
+import 'package:khelo/domain/extensions/widget_extension.dart';
+import 'package:khelo/ui/flow/matches/add_match/select_squad/components/user_detail_sheet.dart';
+import 'package:khelo/ui/flow/score_board/add_substitute/add_substitute_view_model.dart';
+import 'package:khelo/ui/flow/score_board/components/bottom_sheet_wrapper.dart';
+import 'package:khelo/ui/flow/score_board/components/user_cell_view.dart';
+import 'package:khelo/ui/flow/team/add_team_member/components/verify_team_member_sheet.dart';
+import 'package:style/button/primary_button.dart';
+import 'package:style/button/secondary_button.dart';
+import 'package:style/extensions/context_extensions.dart';
+import 'package:style/text/app_text_style.dart';
+import 'package:style/text/search_text_field.dart';
+
+class AddSubstituteSheet extends ConsumerStatefulWidget {
+  static Future<T?> show<T>(
+    BuildContext context, {
+    required List<String> playingSquadIds,
+    required List<UserModel> nonPlayingMembers,
+  }) {
+    HapticFeedback.mediumImpact();
+    return showModalBottomSheet(
+      context: context,
+      showDragHandle: false,
+      enableDrag: false,
+      isScrollControlled: true,
+      useRootNavigator: true,
+      backgroundColor: context.colorScheme.surface,
+      builder: (context) {
+        return Padding(
+          padding:
+              EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+          child: AddSubstituteSheet(
+            nonPlayingMembers: nonPlayingMembers,
+            playingSquadIds: playingSquadIds,
+          ),
+        );
+      },
+    );
+  }
+
+  final List<String> playingSquadIds;
+  final List<UserModel> nonPlayingMembers;
+
+  const AddSubstituteSheet({
+    super.key,
+    required this.playingSquadIds,
+    required this.nonPlayingMembers,
+  });
+
+  @override
+  ConsumerState createState() => _AddSubstituteSheetState();
+}
+
+class _AddSubstituteSheetState extends ConsumerState<AddSubstituteSheet> {
+  UserModel? selectedPlayer;
+  bool isEnabled = false;
+  late List<UserModel> playerList;
+  late AddSubstituteViewNotifier notifier;
+
+  @override
+  void initState() {
+    super.initState();
+    notifier = ref.read(addSubstituteStateProvider.notifier);
+
+    runPostFrame(() => notifier.setData(
+          widget.nonPlayingMembers,
+          widget.playingSquadIds,
+        ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(addSubstituteStateProvider);
+
+    return BottomSheetWrapper(
+      contentBottomSpacing: 0,
+      content: _content(context, state),
+      action: [
+        PrimaryButton(
+          context.l10n.common_select_title,
+          enabled: selectedPlayer != null,
+          onPressed: () {
+            context.pop(selectedPlayer);
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _content(BuildContext context, AddSubstituteViewState state) {
+    if (state.error != null) {
+      return ErrorScreen(
+        error: state.error,
+        onRetryTap: notifier.onSearchChanged,
+      );
+    }
+
+    return SizedBox(
+      height: context.mediaQuerySize.height * 0.8,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            context.l10n.score_board_add_substitute_title,
+            style: AppTextStyle.header3
+                .copyWith(color: context.colorScheme.textPrimary),
+          ),
+          const SizedBox(height: 16),
+          _benchPlayerView(context, state.nonPlayingPlayers),
+          const SizedBox(height: 16),
+          _searchTextField(context, notifier, state),
+          const SizedBox(height: 24),
+          _searchResultView(context, notifier, state),
+        ],
+      ),
+    );
+  }
+
+  Widget _benchPlayerView(BuildContext context, List<UserModel> bench) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: bench.map((player) {
+          return Padding(
+            padding: const EdgeInsets.only(right: 16.0),
+            child: UserCellView(
+              title: player.name ?? context.l10n.common_anonymous_title,
+              imageUrl: player.profile_img_url,
+              initial: player.nameInitial,
+              isSelected: selectedPlayer?.id == player.id,
+              onTap: () => setState(() => selectedPlayer = player),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  Widget _searchResultView(
+    BuildContext context,
+    AddSubstituteViewNotifier notifier,
+    AddSubstituteViewState state,
+  ) {
+    return state.searchedUsers.isEmpty
+        ? EmptyScreen(
+            title: (state.searchController.text.isNotEmpty)
+                ? context.l10n.add_team_member_search_no_result_title
+                : context.l10n.add_substitute_search_substitute_title,
+            description: (state.searchController.text.isNotEmpty)
+                ? context.l10n.add_team_member_search_description_text
+                : context.l10n.add_substitute_search_substitute_description,
+            isShowButton: false,
+          )
+        : Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: state.searchedUsers.map(
+              (user) {
+                final enableAction = !state.playingSquadIds.contains(user.id);
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: UserDetailCell(
+                    user: user,
+                    trailing: _addButton(context, user, enableAction),
+                    onTap: () => UserDetailSheet.show(
+                      context,
+                      user,
+                      actionButtonTitle: enableAction
+                          ? context.l10n.common_select_title
+                          : null,
+                      onButtonTap: () async {
+                        if (user.phone != null) {
+                          final res = await VerifyTeamMemberSheet.show(context,
+                              phoneNumber: user.phone!);
+                          if (res != null && res && context.mounted) {
+                            context.pop(user);
+                          }
+                        }
+                      },
+                    ),
+                  ),
+                );
+              },
+            ).toList(),
+          );
+  }
+
+  Widget _searchTextField(
+    BuildContext context,
+    AddSubstituteViewNotifier notifier,
+    AddSubstituteViewState state,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: SearchTextField(
+        controller: state.searchController,
+        hintText: context.l10n.search_user_hint_title,
+        onChange: notifier.onSearchChanged,
+      ),
+    );
+  }
+
+  Widget _addButton(BuildContext context, UserModel user, bool enabled) {
+    return SecondaryButton(
+      context.l10n.common_select_title,
+      enabled: enabled,
+      onPressed: () async {
+        if (user.phone != null) {
+          final res = await VerifyTeamMemberSheet.show(context,
+              phoneNumber: user.phone!);
+          if (res != null && res && context.mounted) {
+            context.pop(user);
+          }
+        }
+      },
+    );
+  }
+}

--- a/khelo/lib/ui/flow/score_board/add_substitute/add_substitute_sheet.dart
+++ b/khelo/lib/ui/flow/score_board/add_substitute/add_substitute_sheet.dart
@@ -89,7 +89,7 @@ class _AddSubstituteSheetState extends ConsumerState<AddSubstituteSheet> {
       child: Stack(
         children: [
           Padding(
-            padding: EdgeInsets.only(top: 44) +
+            padding: const EdgeInsets.only(top: 44) +
                 const EdgeInsets.symmetric(horizontal: 16.0) +
                 context.mediaQueryPadding,
             child: CustomScrollView(
@@ -152,11 +152,11 @@ class _AddSubstituteSheetState extends ConsumerState<AddSubstituteSheet> {
                   .copyWith(color: context.colorScheme.textPrimary),
             ),
           ),
-          SliverToBoxAdapter(child: const SizedBox(height: 16)),
+          const SliverToBoxAdapter(child: SizedBox(height: 16)),
           SliverToBoxAdapter(
               child: _benchPlayerView(context, state.nonPlayingPlayers)),
           SliverToBoxAdapter(child: _searchTextField(context, notifier, state)),
-          SliverToBoxAdapter(child: const SizedBox(height: 24)),
+          const SliverToBoxAdapter(child: SizedBox(height: 24)),
           SliverFillRemaining(
               hasScrollBody: false,
               child: _searchResultView(context, notifier, state)),

--- a/khelo/lib/ui/flow/score_board/add_substitute/add_substitute_view_model.dart
+++ b/khelo/lib/ui/flow/score_board/add_substitute/add_substitute_view_model.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:data/api/user/user_models.dart';
+import 'package:data/service/user/user_service.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'add_substitute_view_model.freezed.dart';
+
+final addSubstituteStateProvider = StateNotifierProvider.autoDispose<
+    AddSubstituteViewNotifier, AddSubstituteViewState>((ref) {
+  return AddSubstituteViewNotifier(
+    ref.read(userServiceProvider),
+  );
+});
+
+class AddSubstituteViewNotifier extends StateNotifier<AddSubstituteViewState> {
+  final UserService _userService;
+  Timer? _debounce;
+
+  AddSubstituteViewNotifier(this._userService)
+      : super(
+            AddSubstituteViewState(searchController: TextEditingController()));
+
+  void setData(
+    List<UserModel> nonPlayingPlayers,
+    List<String> playingSquadIds,
+  ) {
+    state = state.copyWith(
+        nonPlayingPlayers: nonPlayingPlayers, playingSquadIds: playingSquadIds);
+  }
+
+  Future<void> search(String searchKey) async {
+    try {
+      if (searchKey.isEmpty) {
+        state = state.copyWith(searchedUsers: [], error: null);
+        return;
+      }
+      final users = await _userService.searchUser(searchKey);
+      state = state.copyWith(searchedUsers: users);
+    } catch (e) {
+      state = state.copyWith(error: e);
+      debugPrint("AddSubstituteViewNotifier: error while search user -> $e");
+    }
+  }
+
+  void onSearchChanged() {
+    if (_debounce != null && _debounce!.isActive) {
+      _debounce!.cancel();
+    }
+
+    _debounce = Timer(const Duration(milliseconds: 500), () async {
+      search(state.searchController.text.trim());
+    });
+  }
+
+  void selectUser(UserModel user) {
+    state = state.copyWith(selectedUser: user);
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    super.dispose();
+  }
+}
+
+@freezed
+class AddSubstituteViewState with _$AddSubstituteViewState {
+  const factory AddSubstituteViewState({
+    required TextEditingController searchController,
+    Object? error,
+    UserModel? selectedUser,
+    @Default([]) List<UserModel> searchedUsers,
+    @Default([]) List<UserModel> nonPlayingPlayers,
+    @Default([]) List<String> playingSquadIds,
+  }) = _AddSubstituteViewState;
+}

--- a/khelo/lib/ui/flow/score_board/add_substitute/add_substitute_view_model.freezed.dart
+++ b/khelo/lib/ui/flow/score_board/add_substitute/add_substitute_view_model.freezed.dart
@@ -1,0 +1,289 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'add_substitute_view_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$AddSubstituteViewState {
+  TextEditingController get searchController =>
+      throw _privateConstructorUsedError;
+  Object? get error => throw _privateConstructorUsedError;
+  UserModel? get selectedUser => throw _privateConstructorUsedError;
+  List<UserModel> get searchedUsers => throw _privateConstructorUsedError;
+  List<UserModel> get nonPlayingPlayers => throw _privateConstructorUsedError;
+  List<String> get playingSquadIds => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $AddSubstituteViewStateCopyWith<AddSubstituteViewState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AddSubstituteViewStateCopyWith<$Res> {
+  factory $AddSubstituteViewStateCopyWith(AddSubstituteViewState value,
+          $Res Function(AddSubstituteViewState) then) =
+      _$AddSubstituteViewStateCopyWithImpl<$Res, AddSubstituteViewState>;
+  @useResult
+  $Res call(
+      {TextEditingController searchController,
+      Object? error,
+      UserModel? selectedUser,
+      List<UserModel> searchedUsers,
+      List<UserModel> nonPlayingPlayers,
+      List<String> playingSquadIds});
+
+  $UserModelCopyWith<$Res>? get selectedUser;
+}
+
+/// @nodoc
+class _$AddSubstituteViewStateCopyWithImpl<$Res,
+        $Val extends AddSubstituteViewState>
+    implements $AddSubstituteViewStateCopyWith<$Res> {
+  _$AddSubstituteViewStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? searchController = null,
+    Object? error = freezed,
+    Object? selectedUser = freezed,
+    Object? searchedUsers = null,
+    Object? nonPlayingPlayers = null,
+    Object? playingSquadIds = null,
+  }) {
+    return _then(_value.copyWith(
+      searchController: null == searchController
+          ? _value.searchController
+          : searchController // ignore: cast_nullable_to_non_nullable
+              as TextEditingController,
+      error: freezed == error ? _value.error : error,
+      selectedUser: freezed == selectedUser
+          ? _value.selectedUser
+          : selectedUser // ignore: cast_nullable_to_non_nullable
+              as UserModel?,
+      searchedUsers: null == searchedUsers
+          ? _value.searchedUsers
+          : searchedUsers // ignore: cast_nullable_to_non_nullable
+              as List<UserModel>,
+      nonPlayingPlayers: null == nonPlayingPlayers
+          ? _value.nonPlayingPlayers
+          : nonPlayingPlayers // ignore: cast_nullable_to_non_nullable
+              as List<UserModel>,
+      playingSquadIds: null == playingSquadIds
+          ? _value.playingSquadIds
+          : playingSquadIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $UserModelCopyWith<$Res>? get selectedUser {
+    if (_value.selectedUser == null) {
+      return null;
+    }
+
+    return $UserModelCopyWith<$Res>(_value.selectedUser!, (value) {
+      return _then(_value.copyWith(selectedUser: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$AddSubstituteViewStateImplCopyWith<$Res>
+    implements $AddSubstituteViewStateCopyWith<$Res> {
+  factory _$$AddSubstituteViewStateImplCopyWith(
+          _$AddSubstituteViewStateImpl value,
+          $Res Function(_$AddSubstituteViewStateImpl) then) =
+      __$$AddSubstituteViewStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {TextEditingController searchController,
+      Object? error,
+      UserModel? selectedUser,
+      List<UserModel> searchedUsers,
+      List<UserModel> nonPlayingPlayers,
+      List<String> playingSquadIds});
+
+  @override
+  $UserModelCopyWith<$Res>? get selectedUser;
+}
+
+/// @nodoc
+class __$$AddSubstituteViewStateImplCopyWithImpl<$Res>
+    extends _$AddSubstituteViewStateCopyWithImpl<$Res,
+        _$AddSubstituteViewStateImpl>
+    implements _$$AddSubstituteViewStateImplCopyWith<$Res> {
+  __$$AddSubstituteViewStateImplCopyWithImpl(
+      _$AddSubstituteViewStateImpl _value,
+      $Res Function(_$AddSubstituteViewStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? searchController = null,
+    Object? error = freezed,
+    Object? selectedUser = freezed,
+    Object? searchedUsers = null,
+    Object? nonPlayingPlayers = null,
+    Object? playingSquadIds = null,
+  }) {
+    return _then(_$AddSubstituteViewStateImpl(
+      searchController: null == searchController
+          ? _value.searchController
+          : searchController // ignore: cast_nullable_to_non_nullable
+              as TextEditingController,
+      error: freezed == error ? _value.error : error,
+      selectedUser: freezed == selectedUser
+          ? _value.selectedUser
+          : selectedUser // ignore: cast_nullable_to_non_nullable
+              as UserModel?,
+      searchedUsers: null == searchedUsers
+          ? _value._searchedUsers
+          : searchedUsers // ignore: cast_nullable_to_non_nullable
+              as List<UserModel>,
+      nonPlayingPlayers: null == nonPlayingPlayers
+          ? _value._nonPlayingPlayers
+          : nonPlayingPlayers // ignore: cast_nullable_to_non_nullable
+              as List<UserModel>,
+      playingSquadIds: null == playingSquadIds
+          ? _value._playingSquadIds
+          : playingSquadIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$AddSubstituteViewStateImpl implements _AddSubstituteViewState {
+  const _$AddSubstituteViewStateImpl(
+      {required this.searchController,
+      this.error,
+      this.selectedUser,
+      final List<UserModel> searchedUsers = const [],
+      final List<UserModel> nonPlayingPlayers = const [],
+      final List<String> playingSquadIds = const []})
+      : _searchedUsers = searchedUsers,
+        _nonPlayingPlayers = nonPlayingPlayers,
+        _playingSquadIds = playingSquadIds;
+
+  @override
+  final TextEditingController searchController;
+  @override
+  final Object? error;
+  @override
+  final UserModel? selectedUser;
+  final List<UserModel> _searchedUsers;
+  @override
+  @JsonKey()
+  List<UserModel> get searchedUsers {
+    if (_searchedUsers is EqualUnmodifiableListView) return _searchedUsers;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_searchedUsers);
+  }
+
+  final List<UserModel> _nonPlayingPlayers;
+  @override
+  @JsonKey()
+  List<UserModel> get nonPlayingPlayers {
+    if (_nonPlayingPlayers is EqualUnmodifiableListView)
+      return _nonPlayingPlayers;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_nonPlayingPlayers);
+  }
+
+  final List<String> _playingSquadIds;
+  @override
+  @JsonKey()
+  List<String> get playingSquadIds {
+    if (_playingSquadIds is EqualUnmodifiableListView) return _playingSquadIds;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_playingSquadIds);
+  }
+
+  @override
+  String toString() {
+    return 'AddSubstituteViewState(searchController: $searchController, error: $error, selectedUser: $selectedUser, searchedUsers: $searchedUsers, nonPlayingPlayers: $nonPlayingPlayers, playingSquadIds: $playingSquadIds)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AddSubstituteViewStateImpl &&
+            (identical(other.searchController, searchController) ||
+                other.searchController == searchController) &&
+            const DeepCollectionEquality().equals(other.error, error) &&
+            (identical(other.selectedUser, selectedUser) ||
+                other.selectedUser == selectedUser) &&
+            const DeepCollectionEquality()
+                .equals(other._searchedUsers, _searchedUsers) &&
+            const DeepCollectionEquality()
+                .equals(other._nonPlayingPlayers, _nonPlayingPlayers) &&
+            const DeepCollectionEquality()
+                .equals(other._playingSquadIds, _playingSquadIds));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      searchController,
+      const DeepCollectionEquality().hash(error),
+      selectedUser,
+      const DeepCollectionEquality().hash(_searchedUsers),
+      const DeepCollectionEquality().hash(_nonPlayingPlayers),
+      const DeepCollectionEquality().hash(_playingSquadIds));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AddSubstituteViewStateImplCopyWith<_$AddSubstituteViewStateImpl>
+      get copyWith => __$$AddSubstituteViewStateImplCopyWithImpl<
+          _$AddSubstituteViewStateImpl>(this, _$identity);
+}
+
+abstract class _AddSubstituteViewState implements AddSubstituteViewState {
+  const factory _AddSubstituteViewState(
+      {required final TextEditingController searchController,
+      final Object? error,
+      final UserModel? selectedUser,
+      final List<UserModel> searchedUsers,
+      final List<UserModel> nonPlayingPlayers,
+      final List<String> playingSquadIds}) = _$AddSubstituteViewStateImpl;
+
+  @override
+  TextEditingController get searchController;
+  @override
+  Object? get error;
+  @override
+  UserModel? get selectedUser;
+  @override
+  List<UserModel> get searchedUsers;
+  @override
+  List<UserModel> get nonPlayingPlayers;
+  @override
+  List<String> get playingSquadIds;
+  @override
+  @JsonKey(ignore: true)
+  _$$AddSubstituteViewStateImplCopyWith<_$AddSubstituteViewStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/khelo/lib/ui/flow/score_board/components/bottom_sheet_wrapper.dart
+++ b/khelo/lib/ui/flow/score_board/components/bottom_sheet_wrapper.dart
@@ -5,7 +5,6 @@ import 'package:style/extensions/context_extensions.dart';
 class BottomSheetWrapper extends StatelessWidget {
   final Widget content;
   final bool showDragHandle;
-  final double? height;
   final double contentBottomSpacing;
   final List<Widget> action;
   final List<Widget>? options;
@@ -14,7 +13,6 @@ class BottomSheetWrapper extends StatelessWidget {
     super.key,
     this.showDragHandle = true,
     this.contentBottomSpacing = 70,
-    this.height,
     required this.content,
     required this.action,
     this.options,
@@ -23,7 +21,6 @@ class BottomSheetWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: height,
       constraints:
           BoxConstraints(maxHeight: context.mediaQuerySize.height * 0.8),
       decoration: BoxDecoration(

--- a/khelo/lib/ui/flow/score_board/components/bottom_sheet_wrapper.dart
+++ b/khelo/lib/ui/flow/score_board/components/bottom_sheet_wrapper.dart
@@ -5,6 +5,7 @@ import 'package:style/extensions/context_extensions.dart';
 class BottomSheetWrapper extends StatelessWidget {
   final Widget content;
   final bool showDragHandle;
+  final double? height;
   final double contentBottomSpacing;
   final List<Widget> action;
   final List<Widget>? options;
@@ -13,6 +14,7 @@ class BottomSheetWrapper extends StatelessWidget {
     super.key,
     this.showDragHandle = true,
     this.contentBottomSpacing = 70,
+    this.height,
     required this.content,
     required this.action,
     this.options,
@@ -21,6 +23,7 @@ class BottomSheetWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
+      height: height,
       constraints:
           BoxConstraints(maxHeight: context.mediaQuerySize.height * 0.8),
       decoration: BoxDecoration(

--- a/khelo/lib/ui/flow/score_board/components/select_wicket_taker_sheet.dart
+++ b/khelo/lib/ui/flow/score_board/components/select_wicket_taker_sheet.dart
@@ -77,6 +77,11 @@ class _SelectWicketTakerSheetState
                     title: player.player.name ??
                         context.l10n.common_anonymous_title,
                     imageUrl: player.player.profile_img_url,
+                    subtitle: player.performance.any((element) =>
+                            element.status == PlayerStatus.substitute &&
+                            element.inning_id == state.currentInning?.id)
+                        ? context.l10n.score_board_substitute_title
+                        : null,
                     initial: player.player.nameInitial,
                     isSelected: selectedId == player.player.id,
                     onTap: () {

--- a/khelo/lib/ui/flow/score_board/score_board_screen.dart
+++ b/khelo/lib/ui/flow/score_board/score_board_screen.dart
@@ -11,6 +11,7 @@ import 'package:khelo/components/error_screen.dart';
 import 'package:khelo/components/error_snackbar.dart';
 import 'package:khelo/domain/extensions/context_extensions.dart';
 import 'package:khelo/domain/extensions/widget_extension.dart';
+import 'package:khelo/ui/flow/score_board/add_substitute/add_substitute_sheet.dart';
 import 'package:khelo/ui/flow/score_board/components/add_extra_sheet.dart';
 import 'package:khelo/ui/flow/score_board/components/add_penalty_run_sheet.dart';
 import 'package:khelo/ui/flow/score_board/components/match_complete_sheet.dart';
@@ -71,6 +72,7 @@ class _ScoreBoardScreenState extends ConsumerState<ScoreBoardScreen> {
     _observePop(context, ref);
     _observeShowPauseScoringSheet(context, ref);
     _observeShowAddPenaltyRunSheet(context, ref);
+    _observeShowAddSubstituteSheet(context, ref);
     _observeEndMatchSheet(context, ref);
     _observeInvalidUndoToast(context, ref);
 
@@ -556,16 +558,35 @@ class _ScoreBoardScreenState extends ConsumerState<ScoreBoardScreen> {
     });
   }
 
+  void _observeShowAddSubstituteSheet(BuildContext context, WidgetRef ref) {
+    ref.listen(
+        scoreBoardStateProvider.select((value) => value.showAddSubstituteSheet),
+        (previous, next) async {
+      if (next != null) {
+        final player = await AddSubstituteSheet.show<UserModel>(
+          context,
+          nonPlayingMembers: notifier.getNonPlayingTeamMembers(),
+          playingSquadIds: notifier.getPlayingSquadIds(),
+        );
+        if (context.mounted && player != null) {
+          notifier.addSubstitute(player);
+        }
+      }
+    });
+  }
+
   void _observeEndMatchSheet(BuildContext context, WidgetRef ref) {
     ref.listen(
         scoreBoardStateProvider.select((value) => value.showEndMatchSheet),
         (previous, next) {
       if (next != null) {
-        showConfirmationDialog(context,
-            title: context.l10n.common_end_match_title,
-            message: context.l10n.score_board_end_match_description_text,
-            confirmBtnText: context.l10n.common_okay_title,
-            onConfirm: notifier.abandonMatch);
+        showConfirmationDialog(
+          context,
+          title: context.l10n.common_end_match_title,
+          message: context.l10n.score_board_end_match_description_text,
+          confirmBtnText: context.l10n.common_okay_title,
+          onConfirm: notifier.abandonMatch,
+        );
       }
     });
   }

--- a/khelo/lib/ui/flow/score_board/score_board_view_model.freezed.dart
+++ b/khelo/lib/ui/flow/score_board/score_board_view_model.freezed.dart
@@ -49,6 +49,7 @@ mixin _$ScoreBoardViewState {
   DateTime? get showPauseScoringSheet => throw _privateConstructorUsedError;
   DateTime? get showAddPenaltyRunSheet => throw _privateConstructorUsedError;
   DateTime? get showEndMatchSheet => throw _privateConstructorUsedError;
+  DateTime? get showAddSubstituteSheet => throw _privateConstructorUsedError;
   DateTime? get invalidUndoToast => throw _privateConstructorUsedError;
   ScoreButton? get tappedButton => throw _privateConstructorUsedError;
   bool? get isLongTap => throw _privateConstructorUsedError;
@@ -109,6 +110,7 @@ abstract class $ScoreBoardViewStateCopyWith<$Res> {
       DateTime? showPauseScoringSheet,
       DateTime? showAddPenaltyRunSheet,
       DateTime? showEndMatchSheet,
+      DateTime? showAddSubstituteSheet,
       DateTime? invalidUndoToast,
       ScoreButton? tappedButton,
       bool? isLongTap,
@@ -175,6 +177,7 @@ class _$ScoreBoardViewStateCopyWithImpl<$Res, $Val extends ScoreBoardViewState>
     Object? showPauseScoringSheet = freezed,
     Object? showAddPenaltyRunSheet = freezed,
     Object? showEndMatchSheet = freezed,
+    Object? showAddSubstituteSheet = freezed,
     Object? invalidUndoToast = freezed,
     Object? tappedButton = freezed,
     Object? isLongTap = freezed,
@@ -298,6 +301,10 @@ class _$ScoreBoardViewStateCopyWithImpl<$Res, $Val extends ScoreBoardViewState>
       showEndMatchSheet: freezed == showEndMatchSheet
           ? _value.showEndMatchSheet
           : showEndMatchSheet // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      showAddSubstituteSheet: freezed == showAddSubstituteSheet
+          ? _value.showAddSubstituteSheet
+          : showAddSubstituteSheet // ignore: cast_nullable_to_non_nullable
               as DateTime?,
       invalidUndoToast: freezed == invalidUndoToast
           ? _value.invalidUndoToast
@@ -471,6 +478,7 @@ abstract class _$$ScoreBoardViewStateImplCopyWith<$Res>
       DateTime? showPauseScoringSheet,
       DateTime? showAddPenaltyRunSheet,
       DateTime? showEndMatchSheet,
+      DateTime? showAddSubstituteSheet,
       DateTime? invalidUndoToast,
       ScoreButton? tappedButton,
       bool? isLongTap,
@@ -540,6 +548,7 @@ class __$$ScoreBoardViewStateImplCopyWithImpl<$Res>
     Object? showPauseScoringSheet = freezed,
     Object? showAddPenaltyRunSheet = freezed,
     Object? showEndMatchSheet = freezed,
+    Object? showAddSubstituteSheet = freezed,
     Object? invalidUndoToast = freezed,
     Object? tappedButton = freezed,
     Object? isLongTap = freezed,
@@ -664,6 +673,10 @@ class __$$ScoreBoardViewStateImplCopyWithImpl<$Res>
           ? _value.showEndMatchSheet
           : showEndMatchSheet // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      showAddSubstituteSheet: freezed == showAddSubstituteSheet
+          ? _value.showAddSubstituteSheet
+          : showAddSubstituteSheet // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
       invalidUndoToast: freezed == invalidUndoToast
           ? _value.invalidUndoToast
           : invalidUndoToast // ignore: cast_nullable_to_non_nullable
@@ -771,6 +784,7 @@ class _$ScoreBoardViewStateImpl implements _ScoreBoardViewState {
       this.showPauseScoringSheet,
       this.showAddPenaltyRunSheet,
       this.showEndMatchSheet,
+      this.showAddSubstituteSheet,
       this.invalidUndoToast,
       this.tappedButton,
       this.isLongTap,
@@ -857,6 +871,8 @@ class _$ScoreBoardViewStateImpl implements _ScoreBoardViewState {
   @override
   final DateTime? showEndMatchSheet;
   @override
+  final DateTime? showAddSubstituteSheet;
+  @override
   final DateTime? invalidUndoToast;
   @override
   final ScoreButton? tappedButton;
@@ -929,7 +945,7 @@ class _$ScoreBoardViewStateImpl implements _ScoreBoardViewState {
 
   @override
   String toString() {
-    return 'ScoreBoardViewState(error: $error, actionError: $actionError, match: $match, currentInning: $currentInning, otherInning: $otherInning, bowler: $bowler, strikerId: $strikerId, batsMans: $batsMans, nextInning: $nextInning, showSelectFieldingPositionSheet: $showSelectFieldingPositionSheet, showSelectBatsManSheet: $showSelectBatsManSheet, showSelectBowlerSheet: $showSelectBowlerSheet, showSelectBowlerAndBatsManSheet: $showSelectBowlerAndBatsManSheet, showSelectPlayerSheet: $showSelectPlayerSheet, showSelectWicketTypeSheet: $showSelectWicketTypeSheet, showStrikerSelectionSheet: $showStrikerSelectionSheet, showUndoBallConfirmationDialog: $showUndoBallConfirmationDialog, showOverCompleteSheet: $showOverCompleteSheet, showInningCompleteSheet: $showInningCompleteSheet, showMatchCompleteSheet: $showMatchCompleteSheet, showAddExtraSheetForNoBall: $showAddExtraSheetForNoBall, showAddExtraSheetForLegBye: $showAddExtraSheetForLegBye, showAddExtraSheetForBye: $showAddExtraSheetForBye, showAddExtraSheetForFiveSeven: $showAddExtraSheetForFiveSeven, showPauseScoringSheet: $showPauseScoringSheet, showAddPenaltyRunSheet: $showAddPenaltyRunSheet, showEndMatchSheet: $showEndMatchSheet, invalidUndoToast: $invalidUndoToast, tappedButton: $tappedButton, isLongTap: $isLongTap, position: $position, allInnings: $allInnings, currentScoresList: $currentScoresList, previousScoresList: $previousScoresList, loading: $loading, pop: $pop, continueWithInjuredPlayers: $continueWithInjuredPlayers, ballScoreQueryListenerSet: $ballScoreQueryListenerSet, isMatchUpdated: $isMatchUpdated, isActionInProgress: $isActionInProgress, showForLessRun: $showForLessRun, showForDotBall: $showForDotBall, ballCount: $ballCount, overCount: $overCount, lastAssignedIndex: $lastAssignedIndex)';
+    return 'ScoreBoardViewState(error: $error, actionError: $actionError, match: $match, currentInning: $currentInning, otherInning: $otherInning, bowler: $bowler, strikerId: $strikerId, batsMans: $batsMans, nextInning: $nextInning, showSelectFieldingPositionSheet: $showSelectFieldingPositionSheet, showSelectBatsManSheet: $showSelectBatsManSheet, showSelectBowlerSheet: $showSelectBowlerSheet, showSelectBowlerAndBatsManSheet: $showSelectBowlerAndBatsManSheet, showSelectPlayerSheet: $showSelectPlayerSheet, showSelectWicketTypeSheet: $showSelectWicketTypeSheet, showStrikerSelectionSheet: $showStrikerSelectionSheet, showUndoBallConfirmationDialog: $showUndoBallConfirmationDialog, showOverCompleteSheet: $showOverCompleteSheet, showInningCompleteSheet: $showInningCompleteSheet, showMatchCompleteSheet: $showMatchCompleteSheet, showAddExtraSheetForNoBall: $showAddExtraSheetForNoBall, showAddExtraSheetForLegBye: $showAddExtraSheetForLegBye, showAddExtraSheetForBye: $showAddExtraSheetForBye, showAddExtraSheetForFiveSeven: $showAddExtraSheetForFiveSeven, showPauseScoringSheet: $showPauseScoringSheet, showAddPenaltyRunSheet: $showAddPenaltyRunSheet, showEndMatchSheet: $showEndMatchSheet, showAddSubstituteSheet: $showAddSubstituteSheet, invalidUndoToast: $invalidUndoToast, tappedButton: $tappedButton, isLongTap: $isLongTap, position: $position, allInnings: $allInnings, currentScoresList: $currentScoresList, previousScoresList: $previousScoresList, loading: $loading, pop: $pop, continueWithInjuredPlayers: $continueWithInjuredPlayers, ballScoreQueryListenerSet: $ballScoreQueryListenerSet, isMatchUpdated: $isMatchUpdated, isActionInProgress: $isActionInProgress, showForLessRun: $showForLessRun, showForDotBall: $showForDotBall, ballCount: $ballCount, overCount: $overCount, lastAssignedIndex: $lastAssignedIndex)';
   }
 
   @override
@@ -991,6 +1007,7 @@ class _$ScoreBoardViewStateImpl implements _ScoreBoardViewState {
                 other.showPauseScoringSheet == showPauseScoringSheet) &&
             (identical(other.showAddPenaltyRunSheet, showAddPenaltyRunSheet) || other.showAddPenaltyRunSheet == showAddPenaltyRunSheet) &&
             (identical(other.showEndMatchSheet, showEndMatchSheet) || other.showEndMatchSheet == showEndMatchSheet) &&
+            (identical(other.showAddSubstituteSheet, showAddSubstituteSheet) || other.showAddSubstituteSheet == showAddSubstituteSheet) &&
             (identical(other.invalidUndoToast, invalidUndoToast) || other.invalidUndoToast == invalidUndoToast) &&
             (identical(other.tappedButton, tappedButton) || other.tappedButton == tappedButton) &&
             (identical(other.isLongTap, isLongTap) || other.isLongTap == isLongTap) &&
@@ -1041,6 +1058,7 @@ class _$ScoreBoardViewStateImpl implements _ScoreBoardViewState {
         showPauseScoringSheet,
         showAddPenaltyRunSheet,
         showEndMatchSheet,
+        showAddSubstituteSheet,
         invalidUndoToast,
         tappedButton,
         isLongTap,
@@ -1098,6 +1116,7 @@ abstract class _ScoreBoardViewState implements ScoreBoardViewState {
       final DateTime? showPauseScoringSheet,
       final DateTime? showAddPenaltyRunSheet,
       final DateTime? showEndMatchSheet,
+      final DateTime? showAddSubstituteSheet,
       final DateTime? invalidUndoToast,
       final ScoreButton? tappedButton,
       final bool? isLongTap,
@@ -1171,6 +1190,8 @@ abstract class _ScoreBoardViewState implements ScoreBoardViewState {
   DateTime? get showAddPenaltyRunSheet;
   @override
   DateTime? get showEndMatchSheet;
+  @override
+  DateTime? get showAddSubstituteSheet;
   @override
   DateTime? get invalidUndoToast;
   @override


### PR DESCRIPTION
Add substitute in match scoring for fielding

https://github.com/user-attachments/assets/04abb439-36ef-4305-9b2b-742d900c4774

updated: 

![Simulator Screen Recording - iPhone 15 - 2024-08-27 at 11 36 37](https://github.com/user-attachments/assets/5e2dd459-c885-4c5b-9505-1a45b3914758)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added functionalities for managing substitutes, including search and selection options within the application.
	- Introduced a new UI component for enhancing the user experience in managing player substitutions.

- **Enhancements**
	- Improved the clarity and responsiveness of the user interface regarding player performance status and availability.
	- Enhanced state management for a more dynamic interaction when adding substitutes during gameplay.

- **Bug Fixes**
	- Resolved issues related to the button's interactivity and player eligibility filtering to ensure accurate gameplay management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->