### PR TITLE
Implement tournament teams tab

### DIFF
--- a/data/lib/service/match/match_service.dart
+++ b/data/lib/service/match/match_service.dart
@@ -534,9 +534,7 @@ class MatchService {
     try {
       final teamIds = teamList.map((e) => e.team_id).toList();
 
-      final playerIds = teamList
-          .expand((team) => team.squad.map((player) => player))
-          .toList();
+      final playerIds = teamList.expand((team) => team.squad).toList();
 
       final teamsData = await Future.wait([
         _teamService.getTeamsByIds(teamIds),

--- a/data/lib/service/match/match_service.dart
+++ b/data/lib/service/match/match_service.dart
@@ -533,7 +533,10 @@ class MatchService {
   ) async {
     try {
       final teamIds = teamList.map((e) => e.team_id).toList();
-      final playerIds = teamList.expand((team) => team.squad).toList();
+
+      final playerIds = teamList
+          .expand((team) => team.squad.map((player) => player))
+          .toList();
 
       final teamsData = await Future.wait([
         _teamService.getTeamsByIds(teamIds),
@@ -544,7 +547,10 @@ class MatchService {
       final List<MatchPlayer> players = teamsData[1] as List<MatchPlayer>;
 
       final List<List<MatchPlayer>> squads = teamList.map((team) {
-        return players.where((player) => team.squad.contains(player)).toList();
+        final teamPlayerIds = team.squad.map((player) => player.id).toSet();
+        return players
+            .where((player) => teamPlayerIds.contains(player.id))
+            .toList();
       }).toList();
 
       return List.generate(teamList.length, (index) {

--- a/data/lib/service/tournament/tournament_service.dart
+++ b/data/lib/service/tournament/tournament_service.dart
@@ -145,4 +145,14 @@ class TournamentService {
     return playerStatsList.getTopKeyStats()
       ..sort((a, b) => b.value?.compareTo(a.value ?? 0) ?? 0);
   }
+
+  Future<void> updateTeamIds(String tournamentId, List<String> teamIds) async {
+    try {
+      await _tournamentCollection
+          .doc(tournamentId)
+          .update({FireStoreConst.teamIds: teamIds});
+    } catch (error, stack) {
+      throw AppError.fromError(error, stack);
+    }
+  }
 }

--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -215,6 +215,10 @@
   "tournament_detail_overview_key_stats_title": "Key Stats",
   "tournament_detail_overview_featured_matches_title": "Featured Matches",
 
+  "tournament_detail_teams_empty_title": "Create teams!",
+  "tournament_detail_teams_empty_description": "You don't have a teams yet. Create two to get started.",
+  "tournament_detail_teams_add_btn": "Add teams",
+
   "tournament_detail_key_stat_most_runs_title": "Most Runs",
   "tournament_detail_key_stat_most_wickets_title": "Most Wickets",
   "tournament_detail_key_stat_most_fours_title": "Most Fours",

--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -217,7 +217,7 @@
 
   "tournament_detail_teams_empty_title": "Select Your Teams!",
   "tournament_detail_teams_empty_description": "You haven't added any teams to this tournament yet. Please select or create teams to get started.",
-  "tournament_detail_teams_select_btn": "Select teams",
+  "tournament_detail_teams_select_btn": "Add teams",
 
   "tournament_detail_key_stat_most_runs_title": "Most Runs",
   "tournament_detail_key_stat_most_wickets_title": "Most Wickets",

--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -215,9 +215,9 @@
   "tournament_detail_overview_key_stats_title": "Key Stats",
   "tournament_detail_overview_featured_matches_title": "Featured Matches",
 
-  "tournament_detail_teams_empty_title": "Create teams!",
-  "tournament_detail_teams_empty_description": "You don't have a teams yet. Create two to get started.",
-  "tournament_detail_teams_add_btn": "Add teams",
+  "tournament_detail_teams_empty_title": "Select Your Teams!",
+  "tournament_detail_teams_empty_description": "You haven't added any teams to this tournament yet. Please select or create teams to get started.",
+  "tournament_detail_teams_select_btn": "Select teams",
 
   "tournament_detail_key_stat_most_runs_title": "Most Runs",
   "tournament_detail_key_stat_most_wickets_title": "Most Wickets",

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_overview_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_overview_tab.dart
@@ -32,18 +32,15 @@ class _TournamentDetailOverviewTabState
     extends ConsumerState<TournamentDetailOverviewTab> {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: context.colorScheme.containerLow,
-      child: ListView(
-        padding: context.mediaQueryPadding.copyWith(top: 0) +
-            EdgeInsets.symmetric(horizontal: 16).copyWith(bottom: 40),
-        children: [
-          _featuredMatchesView(context, widget.tournament.matches),
-          _keyStatsView(context, widget.tournament.keyStats),
-          _teamsSquadsView(context, widget.tournament.teams),
-          _infoView(context, widget.tournament),
-        ],
-      ),
+    return ListView(
+      padding: context.mediaQueryPadding.copyWith(top: 0) +
+          EdgeInsets.symmetric(horizontal: 16).copyWith(bottom: 40),
+      children: [
+        _featuredMatchesView(context, widget.tournament.matches),
+        _keyStatsView(context, widget.tournament.keyStats),
+        _teamsSquadsView(context, widget.tournament.teams),
+        _infoView(context, widget.tournament),
+      ],
     );
   }
 
@@ -258,7 +255,7 @@ class _TournamentDetailOverviewTabState
         children: [
           _header(
             context,
-            showViewAll: teams.length >= 3,
+            showViewAll: teams.length > 3,
             title: context.l10n.tournament_detail_overview_teams_squads_title,
             onViewAll: () {},
           ),

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_teams_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_teams_tab.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:khelo/domain/extensions/context_extensions.dart';
 import 'package:khelo/domain/extensions/string_extensions.dart';
-import 'package:khelo/ui/flow/tournament/detail/tournament_detail_view_model.dart';
 import 'package:style/animations/on_tap_scale.dart';
 import 'package:style/button/bottom_sticky_overlay.dart';
 import 'package:style/button/primary_button.dart';
@@ -18,12 +17,12 @@ import '../../../../app_route.dart';
 
 class TournamentDetailTeamsTab extends ConsumerWidget {
   final List<TeamModel> teams;
-  final TournamentDetailStateViewNotifier notifier;
+  final Function(List<TeamModel>) onSelected;
 
   const TournamentDetailTeamsTab({
     super.key,
     required this.teams,
-    required this.notifier,
+    required this.onSelected,
   });
 
   @override
@@ -97,13 +96,13 @@ class TournamentDetailTeamsTab extends ConsumerWidget {
   Widget _stickyButton(BuildContext context) {
     return BottomStickyOverlay(
       child: PrimaryButton(
-        context.l10n.tournament_detail_teams_add_btn,
+        context.l10n.tournament_detail_teams_select_btn,
         onPressed: () async {
           final selectedTeams =
               await AppRoute.teamSelection(selectedTeams: teams)
                   .push<List<TeamModel>>(context);
           if (context.mounted && selectedTeams != null) {
-            notifier.addTeams(selectedTeams);
+            onSelected.call(selectedTeams);
           }
         },
       ),

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_teams_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_teams_tab.dart
@@ -1,0 +1,112 @@
+import 'package:data/api/team/team_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:khelo/domain/extensions/context_extensions.dart';
+import 'package:khelo/domain/extensions/string_extensions.dart';
+import 'package:khelo/ui/flow/tournament/detail/tournament_detail_view_model.dart';
+import 'package:style/animations/on_tap_scale.dart';
+import 'package:style/button/bottom_sticky_overlay.dart';
+import 'package:style/button/primary_button.dart';
+import 'package:style/extensions/context_extensions.dart';
+import 'package:style/text/app_text_style.dart';
+
+import '../../../../../components/empty_screen.dart';
+import '../../../../../components/image_avatar.dart';
+import '../../../../../gen/assets.gen.dart';
+import '../../../../app_route.dart';
+
+class TournamentDetailTeamsTab extends ConsumerWidget {
+  final List<TeamModel> teams;
+  final TournamentDetailStateViewNotifier notifier;
+
+  const TournamentDetailTeamsTab({
+    super.key,
+    required this.teams,
+    required this.notifier,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (teams.isEmpty) {
+      return Stack(
+        children: [
+          EmptyScreen(
+            title: context.l10n.tournament_detail_teams_empty_title,
+            description: context.l10n.tournament_detail_teams_empty_description,
+            isShowButton: false,
+          ),
+          _stickyButton(context),
+        ],
+      );
+    }
+
+    return ListView.separated(
+      itemCount: teams.length,
+      padding: context.mediaQueryPadding.copyWith(top: 0) +
+          EdgeInsets.all(16).copyWith(bottom: 24),
+      itemBuilder: (context, index) {
+        return _teamCellView(context, teams[index]);
+      },
+      separatorBuilder: (context, index) => SizedBox(height: 16),
+    );
+  }
+
+  Widget _teamCellView(BuildContext context, TeamModel team) {
+    return OnTapScale(
+      onTap: () => AppRoute.teamDetail(teamId: team.id).push(context),
+      child: Material(
+        type: MaterialType.transparency,
+        child: ListTile(
+          tileColor: context.colorScheme.surface,
+          shape: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide.none,
+          ),
+          leading: ImageAvatar(
+            initial: team.name_initial ?? team.name.initials(limit: 1),
+            imageUrl: team.profile_img_url,
+            size: 40,
+          ),
+          title: Text(
+            team.name,
+            style: AppTextStyle.subtitle2
+                .copyWith(color: context.colorScheme.textPrimary),
+          ),
+          subtitle: team.players.isNotEmpty
+              ? Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                      '${team.players.length} ${context.l10n.add_team_players_text}',
+                      style: AppTextStyle.body2
+                          .copyWith(color: context.colorScheme.textDisabled)),
+                )
+              : null,
+          trailing: SvgPicture.asset(
+            Assets.images.icArrowForward,
+            colorFilter: ColorFilter.mode(
+              context.colorScheme.textDisabled,
+              BlendMode.srcATop,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _stickyButton(BuildContext context) {
+    return BottomStickyOverlay(
+      child: PrimaryButton(
+        context.l10n.tournament_detail_teams_add_btn,
+        onPressed: () async {
+          final selectedTeams =
+              await AppRoute.teamSelection(selectedTeams: teams)
+                  .push<List<TeamModel>>(context);
+          if (context.mounted && selectedTeams != null) {
+            notifier.addTeams(selectedTeams);
+          }
+        },
+      ),
+    );
+  }
+}

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
@@ -127,7 +127,6 @@ class _TournamentDetailScreenState
       color: context.colorScheme.containerLow,
       child: PageView(
         controller: _controller,
-        physics: const NeverScrollableScrollPhysics(),
         onPageChanged: notifier.onTabChange,
         children: [
           TournamentDetailOverviewTab(
@@ -135,7 +134,7 @@ class _TournamentDetailScreenState
           ),
           TournamentDetailTeamsTab(
             teams: state.tournament?.teams ?? [],
-            notifier: notifier,
+            onSelected: notifier.onTeamsSelected,
           ),
         ],
       ),

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
@@ -9,6 +9,7 @@ import 'package:khelo/domain/extensions/context_extensions.dart';
 import 'package:khelo/domain/formatter/date_formatter.dart';
 import 'package:khelo/ui/flow/tournament/components/sliver_header_delegate.dart';
 import 'package:khelo/ui/flow/tournament/detail/tabs/tournament_detail_overview_tab.dart';
+import 'package:khelo/ui/flow/tournament/detail/tabs/tournament_detail_teams_tab.dart';
 import 'package:khelo/ui/flow/tournament/detail/tournament_detail_view_model.dart';
 import 'package:style/button/more_option_button.dart';
 import 'package:style/button/tab_button.dart';
@@ -18,6 +19,7 @@ import 'package:style/text/app_text_style.dart';
 
 import '../../../../components/app_page.dart';
 import '../../../../components/error_screen.dart';
+import '../../../../components/error_snackbar.dart';
 import '../../../../domain/extensions/widget_extension.dart';
 import '../../../../gen/assets.gen.dart';
 
@@ -53,9 +55,22 @@ class _TournamentDetailScreenState
     runPostFrame(() => notifier.setData(widget.tournamentId));
   }
 
+  void _observeActionError(BuildContext context) {
+    ref.listen(
+        tournamentDetailStateProvider.select((value) => value.actionError),
+        (previous, next) {
+      if (next != null) {
+        showErrorSnackBar(context: context, error: next);
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
+    _observeActionError(context);
+
     final state = ref.watch(tournamentDetailStateProvider);
+
     return AppPage(
       body: Builder(builder: (context) {
         return _body(context, state);
@@ -108,15 +123,22 @@ class _TournamentDetailScreenState
   }
 
   Widget _content(BuildContext context, TournamentDetailState state) {
-    return PageView(
-      controller: _controller,
-      physics: const NeverScrollableScrollPhysics(),
-      onPageChanged: notifier.onTabChange,
-      children: [
-        TournamentDetailOverviewTab(
-          tournament: state.tournament!,
-        ),
-      ],
+    return Container(
+      color: context.colorScheme.containerLow,
+      child: PageView(
+        controller: _controller,
+        physics: const NeverScrollableScrollPhysics(),
+        onPageChanged: notifier.onTabChange,
+        children: [
+          TournamentDetailOverviewTab(
+            tournament: state.tournament!,
+          ),
+          TournamentDetailTeamsTab(
+            teams: state.tournament?.teams ?? [],
+            notifier: notifier,
+          ),
+        ],
+      ),
     );
   }
 

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:data/api/team/team_model.dart';
 import 'package:data/api/tournament/tournament_model.dart';
 import 'package:data/service/tournament/tournament_service.dart';
 import 'package:flutter/material.dart';
@@ -52,6 +53,18 @@ class TournamentDetailStateViewNotifier
     }
   }
 
+  void addTeams(List<TeamModel> teams) async {
+    if (state.tournament == null) return;
+    try {
+      final teamIds = teams.map((e) => e.id).toList();
+      await _tournamentService.updateTeamIds(state.tournament!.id, teamIds);
+    } catch (e) {
+      state = state.copyWith(actionError: e);
+      debugPrint(
+          "TournamentDetailStateViewNotifier: error while adding teams -> $e");
+    }
+  }
+
   @override
   void dispose() {
     _tournamentSubscription?.cancel();
@@ -66,5 +79,6 @@ class TournamentDetailState with _$TournamentDetailState {
     @Default(false) bool loading,
     @Default(0) int selectedTab,
     Object? error,
+    Object? actionError,
   }) = _TournamentDetailState;
 }

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.dart
@@ -53,7 +53,7 @@ class TournamentDetailStateViewNotifier
     }
   }
 
-  void addTeams(List<TeamModel> teams) async {
+  void onTeamsSelected(List<TeamModel> teams) async {
     if (state.tournament == null) return;
     try {
       final teamIds = teams.map((e) => e.id).toList();
@@ -61,7 +61,7 @@ class TournamentDetailStateViewNotifier
     } catch (e) {
       state = state.copyWith(actionError: e);
       debugPrint(
-          "TournamentDetailStateViewNotifier: error while adding teams -> $e");
+          "TournamentDetailStateViewNotifier: error while selecting teams -> $e");
     }
   }
 

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.freezed.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.freezed.dart
@@ -20,6 +20,7 @@ mixin _$TournamentDetailState {
   bool get loading => throw _privateConstructorUsedError;
   int get selectedTab => throw _privateConstructorUsedError;
   Object? get error => throw _privateConstructorUsedError;
+  Object? get actionError => throw _privateConstructorUsedError;
 
   /// Create a copy of TournamentDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -38,7 +39,8 @@ abstract class $TournamentDetailStateCopyWith<$Res> {
       {TournamentModel? tournament,
       bool loading,
       int selectedTab,
-      Object? error});
+      Object? error,
+      Object? actionError});
 
   $TournamentModelCopyWith<$Res>? get tournament;
 }
@@ -63,6 +65,7 @@ class _$TournamentDetailStateCopyWithImpl<$Res,
     Object? loading = null,
     Object? selectedTab = null,
     Object? error = freezed,
+    Object? actionError = freezed,
   }) {
     return _then(_value.copyWith(
       tournament: freezed == tournament
@@ -78,6 +81,7 @@ class _$TournamentDetailStateCopyWithImpl<$Res,
           : selectedTab // ignore: cast_nullable_to_non_nullable
               as int,
       error: freezed == error ? _value.error : error,
+      actionError: freezed == actionError ? _value.actionError : actionError,
     ) as $Val);
   }
 
@@ -109,7 +113,8 @@ abstract class _$$TournamentDetailStateImplCopyWith<$Res>
       {TournamentModel? tournament,
       bool loading,
       int selectedTab,
-      Object? error});
+      Object? error,
+      Object? actionError});
 
   @override
   $TournamentModelCopyWith<$Res>? get tournament;
@@ -133,6 +138,7 @@ class __$$TournamentDetailStateImplCopyWithImpl<$Res>
     Object? loading = null,
     Object? selectedTab = null,
     Object? error = freezed,
+    Object? actionError = freezed,
   }) {
     return _then(_$TournamentDetailStateImpl(
       tournament: freezed == tournament
@@ -148,6 +154,7 @@ class __$$TournamentDetailStateImplCopyWithImpl<$Res>
           : selectedTab // ignore: cast_nullable_to_non_nullable
               as int,
       error: freezed == error ? _value.error : error,
+      actionError: freezed == actionError ? _value.actionError : actionError,
     ));
   }
 }
@@ -159,7 +166,8 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
       {this.tournament = null,
       this.loading = false,
       this.selectedTab = 0,
-      this.error});
+      this.error,
+      this.actionError});
 
   @override
   @JsonKey()
@@ -172,10 +180,12 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
   final int selectedTab;
   @override
   final Object? error;
+  @override
+  final Object? actionError;
 
   @override
   String toString() {
-    return 'TournamentDetailState(tournament: $tournament, loading: $loading, selectedTab: $selectedTab, error: $error)';
+    return 'TournamentDetailState(tournament: $tournament, loading: $loading, selectedTab: $selectedTab, error: $error, actionError: $actionError)';
   }
 
   @override
@@ -188,12 +198,19 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
             (identical(other.loading, loading) || other.loading == loading) &&
             (identical(other.selectedTab, selectedTab) ||
                 other.selectedTab == selectedTab) &&
-            const DeepCollectionEquality().equals(other.error, error));
+            const DeepCollectionEquality().equals(other.error, error) &&
+            const DeepCollectionEquality()
+                .equals(other.actionError, actionError));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, tournament, loading, selectedTab,
-      const DeepCollectionEquality().hash(error));
+  int get hashCode => Object.hash(
+      runtimeType,
+      tournament,
+      loading,
+      selectedTab,
+      const DeepCollectionEquality().hash(error),
+      const DeepCollectionEquality().hash(actionError));
 
   /// Create a copy of TournamentDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -210,7 +227,8 @@ abstract class _TournamentDetailState implements TournamentDetailState {
       {final TournamentModel? tournament,
       final bool loading,
       final int selectedTab,
-      final Object? error}) = _$TournamentDetailStateImpl;
+      final Object? error,
+      final Object? actionError}) = _$TournamentDetailStateImpl;
 
   @override
   TournamentModel? get tournament;
@@ -220,6 +238,8 @@ abstract class _TournamentDetailState implements TournamentDetailState {
   int get selectedTab;
   @override
   Object? get error;
+  @override
+  Object? get actionError;
 
   /// Create a copy of TournamentDetailState
   /// with the given fields replaced by the non-null parameter values.


### PR DESCRIPTION
- Implement tournament teams tab list and empty view 

[tournament_teams_tab.webm](https://github.com/user-attachments/assets/728e9a5d-6740-49b3-bc21-80ea15dcf122)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new tab for team details in the tournament detail view.
  - Added functionality to update team IDs associated with tournaments.
  - Enhanced user prompts for creating teams when none exist.

- **Bug Fixes**
  - Improved error handling for team addition and tournament updates.

- **Improvements**
  - Streamlined widget structure for better performance and clarity.
  - Enhanced localization support for tournament management.
  - Added error reporting for team selection processes.

- **UI Changes**
  - Adjusted visibility logic for the "View All" button based on team count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->