### PR TITLE
Implement tournament matches tab

### DIFF
--- a/data/lib/service/tournament/tournament_service.dart
+++ b/data/lib/service/tournament/tournament_service.dart
@@ -146,11 +146,27 @@ class TournamentService {
       ..sort((a, b) => b.value?.compareTo(a.value ?? 0) ?? 0);
   }
 
-  Future<void> updateTeamIds(String tournamentId, List<String> teamIds) async {
+  Future<void> updateTeamIds(
+    String tournamentId,
+    List<String> teamIds,
+  ) async {
     try {
       await _tournamentCollection
           .doc(tournamentId)
           .update({FireStoreConst.teamIds: teamIds});
+    } catch (error, stack) {
+      throw AppError.fromError(error, stack);
+    }
+  }
+
+  Future<void> updateMatchIds(
+    String tournamentId,
+    List<String> matchIds,
+  ) async {
+    try {
+      await _tournamentCollection
+          .doc(tournamentId)
+          .update({FireStoreConst.matchIds: matchIds});
     } catch (error, stack) {
       throw AppError.fromError(error, stack);
     }

--- a/data/lib/utils/constant/firestore_constant.dart
+++ b/data/lib/utils/constant/firestore_constant.dart
@@ -58,6 +58,7 @@ class FireStoreConst {
 
   // tournament field const
   static const String members = "members";
+  static const String matchIds = "match_ids";
 }
 
 class DataConfig {

--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -219,6 +219,12 @@
   "tournament_detail_teams_empty_description": "You haven't added any teams to this tournament yet. Please select or create teams to get started.",
   "tournament_detail_teams_select_btn": "Add teams",
 
+  "tournament_detail_matches_empty_title": "Schedule Your Matches!",
+  "tournament_detail_matches_empty_description": "Create matches to kick off your tournament and get the games started!",
+  "tournament_detail_matches_add_btn": "Add matches",
+  "tournament_detail_matches_filter_by_teams_title": "Filter by teams",
+  "tournament_detail_matches_filter_all_teams_option": "All Teams",
+
   "tournament_detail_key_stat_most_runs_title": "Most Runs",
   "tournament_detail_key_stat_most_wickets_title": "Most Wickets",
   "tournament_detail_key_stat_most_fours_title": "Most Fours",

--- a/khelo/lib/components/match_detail_cell.dart
+++ b/khelo/lib/components/match_detail_cell.dart
@@ -18,6 +18,7 @@ class MatchDetailCell extends StatelessWidget {
   final bool showStatusTag;
   final bool showActionButtons;
   final VoidCallback? onActionTap;
+  final Color? backgroundColor;
 
   const MatchDetailCell({
     super.key,
@@ -25,6 +26,7 @@ class MatchDetailCell extends StatelessWidget {
     required this.onTap,
     this.showStatusTag = true,
     this.showActionButtons = false,
+    this.backgroundColor,
     this.onActionTap,
   });
 
@@ -35,7 +37,7 @@ class MatchDetailCell extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: context.colorScheme.containerLow,
+          color: backgroundColor ?? context.colorScheme.containerLow,
           border: Border.all(color: context.colorScheme.outline),
           borderRadius: BorderRadius.circular(16),
         ),

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_matches_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_matches_tab.dart
@@ -1,30 +1,163 @@
 import 'package:data/api/match/match_model.dart';
+import 'package:data/api/team/team_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:khelo/components/match_detail_cell.dart';
+import 'package:khelo/domain/extensions/context_extensions.dart';
+import 'package:khelo/ui/app_route.dart';
+import 'package:style/button/bottom_sticky_overlay.dart';
+import 'package:style/button/primary_button.dart';
 import 'package:style/extensions/context_extensions.dart';
+import 'package:style/text/app_text_style.dart';
+
+import '../../../../../components/action_bottom_sheet.dart';
+import '../../../../../components/empty_screen.dart';
+import '../../../../../gen/assets.gen.dart';
+import '../tournament_detail_view_model.dart';
 
 class TournamentDetailMatchesTab extends ConsumerWidget {
-  final List<MatchModel> matches;
+  final List<TeamModel> teams;
+  final List<MatchModel> filteredMatches;
+  final Function(String) onMatchFilter;
+  final Function(List<MatchModel>) onSelected;
 
   const TournamentDetailMatchesTab({
     super.key,
-    required this.matches,
+    required this.teams,
+    required this.filteredMatches,
+    required this.onMatchFilter,
+    required this.onSelected,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ListView.separated(
-      itemCount: matches.length,
+    final state = ref.watch(tournamentDetailStateProvider);
+    if (filteredMatches.isEmpty) {
+      return Stack(
+        children: [
+          EmptyScreen(
+            title: context.l10n.tournament_detail_matches_empty_title,
+            description:
+                context.l10n.tournament_detail_matches_empty_description,
+            isShowButton: false,
+          ),
+          _stickyButton(context),
+        ],
+      );
+    }
+
+    return ListView(
       padding: context.mediaQueryPadding.copyWith(top: 0) +
-          EdgeInsets.symmetric(horizontal: 16).copyWith(bottom: 40),
-      itemBuilder: (context, index) {
-        return MatchDetailCell(
-          match: matches[index],
-          onTap: () {},
-        );
-      },
-      separatorBuilder: (context, index) => SizedBox(height: 16),
+          EdgeInsets.all(16).copyWith(bottom: 24),
+      children: [
+        _filterView(context, state),
+        ...filteredMatches.map(
+          (match) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: MatchDetailCell(
+                backgroundColor: context.colorScheme.surface,
+                match: match,
+                onTap: () =>
+                    AppRoute.matchDetailTab(matchId: match.id).push(context),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _filterView(BuildContext context, TournamentDetailState state) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          context.l10n.tournament_detail_matches_filter_by_teams_title,
+          style: AppTextStyle.header4.copyWith(
+            color: context.colorScheme.textPrimary,
+          ),
+        ),
+        TextButton.icon(
+          iconAlignment: IconAlignment.end,
+          onPressed: () => showFilterOptionSelectionSheet(
+            context,
+            matchFilter: state.matchFilter,
+            onTap: onMatchFilter,
+          ),
+          label: Text(
+            state.matchFilter ??
+                context.l10n.tournament_detail_matches_filter_all_teams_option,
+            style: AppTextStyle.body2.copyWith(
+              color: context.colorScheme.primary,
+            ),
+          ),
+          icon: SvgPicture.asset(
+            Assets.images.icArrowDown,
+            height: 18,
+            width: 18,
+            colorFilter: ColorFilter.mode(
+              context.colorScheme.primary,
+              BlendMode.srcATop,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void showFilterOptionSelectionSheet(
+    BuildContext context, {
+    required Function(String) onTap,
+    String? matchFilter,
+  }) async {
+    final filterOptions = [
+      context.l10n.tournament_detail_matches_filter_all_teams_option,
+      ...teams.map((e) => e.name)
+    ];
+    final matchFiltered = matchFilter ?? filterOptions.first;
+    return await showActionBottomSheet(
+        context: context,
+        items: filterOptions
+            .map((option) => BottomSheetAction(
+                  title: option,
+                  enabled: matchFiltered != option,
+                  child: _checkWidget(
+                    context,
+                    isShowCheck: matchFiltered == option,
+                  ),
+                  onTap: () {
+                    context.pop();
+                    onTap(option);
+                  },
+                ))
+            .toList());
+  }
+
+  Widget? _checkWidget(
+    BuildContext context, {
+    required bool isShowCheck,
+  }) =>
+      isShowCheck
+          ? SvgPicture.asset(
+              Assets.images.icCheck,
+              colorFilter: ColorFilter.mode(
+                context.colorScheme.primary,
+                BlendMode.srcATop,
+              ),
+            )
+          : null;
+
+  Widget _stickyButton(BuildContext context) {
+    return BottomStickyOverlay(
+      child: PrimaryButton(
+        context.l10n.tournament_detail_matches_add_btn,
+        onPressed: () {
+          onSelected.call([]);
+        },
+      ),
     );
   }
 }

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_matches_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_matches_tab.dart
@@ -1,0 +1,30 @@
+import 'package:data/api/match/match_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:khelo/components/match_detail_cell.dart';
+import 'package:style/extensions/context_extensions.dart';
+
+class TournamentDetailMatchesTab extends ConsumerWidget {
+  final List<MatchModel> matches;
+
+  const TournamentDetailMatchesTab({
+    super.key,
+    required this.matches,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListView.separated(
+      itemCount: matches.length,
+      padding: context.mediaQueryPadding.copyWith(top: 0) +
+          EdgeInsets.symmetric(horizontal: 16).copyWith(bottom: 40),
+      itemBuilder: (context, index) {
+        return MatchDetailCell(
+          match: matches[index],
+          onTap: () {},
+        );
+      },
+      separatorBuilder: (context, index) => SizedBox(height: 16),
+    );
+  }
+}

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_overview_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_overview_tab.dart
@@ -261,18 +261,15 @@ class _TournamentDetailOverviewTabState
           ),
           const SizedBox(height: 8),
           SizedBox(
-            height: 130,
-            child: ListView.separated(
-              shrinkWrap: true,
+            height: 136,
+            child: SingleChildScrollView(
               scrollDirection: Axis.horizontal,
-              itemBuilder: (context, index) => _teamCellView(
-                context,
-                teams[index],
+              child: Row(
+                children:
+                    teams.map((team) => _teamCellView(context, team)).toList(),
               ),
-              separatorBuilder: (context, index) => const SizedBox(width: 16),
-              itemCount: teams.length,
             ),
-          )
+          ),
         ],
       ),
     );
@@ -284,6 +281,7 @@ class _TournamentDetailOverviewTabState
       child: Container(
         width: 120,
         padding: EdgeInsets.all(16),
+        margin: EdgeInsets.symmetric(horizontal: 8),
         decoration: BoxDecoration(
           color: context.colorScheme.surface,
           borderRadius: BorderRadius.circular(16),
@@ -303,6 +301,7 @@ class _TournamentDetailOverviewTabState
                   color: context.colorScheme.textPrimary,
                 ),
                 textAlign: TextAlign.center,
+                textScaler: TextScaler.noScaling,
               ),
             )
           ],

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:khelo/components/image_avatar.dart';
 import 'package:khelo/domain/extensions/context_extensions.dart';
 import 'package:khelo/domain/formatter/date_formatter.dart';
 import 'package:khelo/ui/flow/tournament/components/sliver_header_delegate.dart';
+import 'package:khelo/ui/flow/tournament/detail/tabs/tournament_detail_matches_tab.dart';
 import 'package:khelo/ui/flow/tournament/detail/tabs/tournament_detail_overview_tab.dart';
 import 'package:khelo/ui/flow/tournament/detail/tournament_detail_view_model.dart';
 import 'package:style/button/more_option_button.dart';
@@ -115,6 +116,9 @@ class _TournamentDetailScreenState
       children: [
         TournamentDetailOverviewTab(
           tournament: state.tournament!,
+        ),
+        TournamentDetailMatchesTab(
+          matches: state.tournament!.matches,
         ),
       ],
     );

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
@@ -138,7 +138,10 @@ class _TournamentDetailScreenState
             onSelected: notifier.onTeamsSelected,
           ),
           TournamentDetailMatchesTab(
-            matches: state.tournament!.matches,
+            teams: state.tournament!.teams,
+            filteredMatches: state.filteredMatches,
+            onMatchFilter: notifier.onMatchFilter,
+            onSelected: notifier.onMatchesSelected,
           ),
         ],
       ),

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.freezed.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.freezed.dart
@@ -21,6 +21,8 @@ mixin _$TournamentDetailState {
   int get selectedTab => throw _privateConstructorUsedError;
   Object? get error => throw _privateConstructorUsedError;
   Object? get actionError => throw _privateConstructorUsedError;
+  String? get matchFilter => throw _privateConstructorUsedError;
+  List<MatchModel> get filteredMatches => throw _privateConstructorUsedError;
 
   /// Create a copy of TournamentDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -40,7 +42,9 @@ abstract class $TournamentDetailStateCopyWith<$Res> {
       bool loading,
       int selectedTab,
       Object? error,
-      Object? actionError});
+      Object? actionError,
+      String? matchFilter,
+      List<MatchModel> filteredMatches});
 
   $TournamentModelCopyWith<$Res>? get tournament;
 }
@@ -66,6 +70,8 @@ class _$TournamentDetailStateCopyWithImpl<$Res,
     Object? selectedTab = null,
     Object? error = freezed,
     Object? actionError = freezed,
+    Object? matchFilter = freezed,
+    Object? filteredMatches = null,
   }) {
     return _then(_value.copyWith(
       tournament: freezed == tournament
@@ -82,6 +88,14 @@ class _$TournamentDetailStateCopyWithImpl<$Res,
               as int,
       error: freezed == error ? _value.error : error,
       actionError: freezed == actionError ? _value.actionError : actionError,
+      matchFilter: freezed == matchFilter
+          ? _value.matchFilter
+          : matchFilter // ignore: cast_nullable_to_non_nullable
+              as String?,
+      filteredMatches: null == filteredMatches
+          ? _value.filteredMatches
+          : filteredMatches // ignore: cast_nullable_to_non_nullable
+              as List<MatchModel>,
     ) as $Val);
   }
 
@@ -114,7 +128,9 @@ abstract class _$$TournamentDetailStateImplCopyWith<$Res>
       bool loading,
       int selectedTab,
       Object? error,
-      Object? actionError});
+      Object? actionError,
+      String? matchFilter,
+      List<MatchModel> filteredMatches});
 
   @override
   $TournamentModelCopyWith<$Res>? get tournament;
@@ -139,6 +155,8 @@ class __$$TournamentDetailStateImplCopyWithImpl<$Res>
     Object? selectedTab = null,
     Object? error = freezed,
     Object? actionError = freezed,
+    Object? matchFilter = freezed,
+    Object? filteredMatches = null,
   }) {
     return _then(_$TournamentDetailStateImpl(
       tournament: freezed == tournament
@@ -155,6 +173,14 @@ class __$$TournamentDetailStateImplCopyWithImpl<$Res>
               as int,
       error: freezed == error ? _value.error : error,
       actionError: freezed == actionError ? _value.actionError : actionError,
+      matchFilter: freezed == matchFilter
+          ? _value.matchFilter
+          : matchFilter // ignore: cast_nullable_to_non_nullable
+              as String?,
+      filteredMatches: null == filteredMatches
+          ? _value._filteredMatches
+          : filteredMatches // ignore: cast_nullable_to_non_nullable
+              as List<MatchModel>,
     ));
   }
 }
@@ -167,7 +193,10 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
       this.loading = false,
       this.selectedTab = 0,
       this.error,
-      this.actionError});
+      this.actionError,
+      this.matchFilter = null,
+      final List<MatchModel> filteredMatches = const []})
+      : _filteredMatches = filteredMatches;
 
   @override
   @JsonKey()
@@ -182,10 +211,21 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
   final Object? error;
   @override
   final Object? actionError;
+  @override
+  @JsonKey()
+  final String? matchFilter;
+  final List<MatchModel> _filteredMatches;
+  @override
+  @JsonKey()
+  List<MatchModel> get filteredMatches {
+    if (_filteredMatches is EqualUnmodifiableListView) return _filteredMatches;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_filteredMatches);
+  }
 
   @override
   String toString() {
-    return 'TournamentDetailState(tournament: $tournament, loading: $loading, selectedTab: $selectedTab, error: $error, actionError: $actionError)';
+    return 'TournamentDetailState(tournament: $tournament, loading: $loading, selectedTab: $selectedTab, error: $error, actionError: $actionError, matchFilter: $matchFilter, filteredMatches: $filteredMatches)';
   }
 
   @override
@@ -200,7 +240,11 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
                 other.selectedTab == selectedTab) &&
             const DeepCollectionEquality().equals(other.error, error) &&
             const DeepCollectionEquality()
-                .equals(other.actionError, actionError));
+                .equals(other.actionError, actionError) &&
+            (identical(other.matchFilter, matchFilter) ||
+                other.matchFilter == matchFilter) &&
+            const DeepCollectionEquality()
+                .equals(other._filteredMatches, _filteredMatches));
   }
 
   @override
@@ -210,7 +254,9 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
       loading,
       selectedTab,
       const DeepCollectionEquality().hash(error),
-      const DeepCollectionEquality().hash(actionError));
+      const DeepCollectionEquality().hash(actionError),
+      matchFilter,
+      const DeepCollectionEquality().hash(_filteredMatches));
 
   /// Create a copy of TournamentDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -228,7 +274,9 @@ abstract class _TournamentDetailState implements TournamentDetailState {
       final bool loading,
       final int selectedTab,
       final Object? error,
-      final Object? actionError}) = _$TournamentDetailStateImpl;
+      final Object? actionError,
+      final String? matchFilter,
+      final List<MatchModel> filteredMatches}) = _$TournamentDetailStateImpl;
 
   @override
   TournamentModel? get tournament;
@@ -240,6 +288,10 @@ abstract class _TournamentDetailState implements TournamentDetailState {
   Object? get error;
   @override
   Object? get actionError;
+  @override
+  String? get matchFilter;
+  @override
+  List<MatchModel> get filteredMatches;
 
   /// Create a copy of TournamentDetailState
   /// with the given fields replaced by the non-null parameter values.


### PR DESCRIPTION
- Implement tournament matches tab 
         -   Matches filter option according teams
         -   Empty view  with select action     
 
[matches_tab.webm](https://github.com/user-attachments/assets/d61d3216-0fe4-47b1-9a1c-49d928c110f0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced match management capabilities, including the ability to update match IDs and filter matches within tournaments.
  - Added a new tab in the tournament detail screen to display match-related information.

- **Enhancements**
  - Improved user interface with new localization entries for tournament match management.
  - Enhanced `MatchDetailCell` for customizable background colors.

- **Bug Fixes**
  - Implemented error handling for match selection and filtering processes.

These updates aim to streamline tournament management and improve user interaction with match details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->