### PR TITLE
Implement tournament detail stats tab

### DIFF
--- a/data/lib/service/tournament/tournament_service.dart
+++ b/data/lib/service/tournament/tournament_service.dart
@@ -141,9 +141,10 @@ class TournamentService {
         }
       }
     }
-
-    return playerStatsList.getTopKeyStats()
+    final keyStats = playerStatsList.getTopKeyStats()
       ..sort((a, b) => b.value?.compareTo(a.value ?? 0) ?? 0);
+
+    return keyStats.where((element) => element.player.isActive).toList();
   }
 
   Future<void> updateTeamIds(

--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -230,6 +230,15 @@
   "tournament_detail_key_stat_most_fours_title": "Most Fours",
   "tournament_detail_key_stat_most_sixes_title": "Most Sixes",
 
+  "tournament_detail_stats_empty_title": "No stats available yet!",
+  "tournament_detail_stats_empty_description": "The players are warming up! Stay tuned for exciting stats as the team progresses.",
+  "tournament_detail_stats_empty_filter_title": "No Stats Found",
+  "tournament_detail_stats_empty_filter_description": "Please try a different filter.",
+  "tournament_detail_stats_player_title": "Player",
+  "tournament_detail_stats_m_title": "M",
+  "tournament_detail_stats_avg_title": "Avg",
+  "tournament_detail_stats_runs_title": "Runs",
+
   "@_TOURNAMENT_TYPE":{
   },
   "tournament_type_knock_out": "Knockout",

--- a/khelo/lib/components/action_bottom_sheet.dart
+++ b/khelo/lib/components/action_bottom_sheet.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:style/animations/on_tap_scale.dart';
 import 'package:style/extensions/context_extensions.dart';
 import 'package:style/extensions/column_extensions.dart';
 import 'package:style/text/app_text_style.dart';
+
+import '../gen/assets.gen.dart';
 
 Future<T?> showActionBottomSheet<T>({
   required BuildContext context,
@@ -60,6 +63,7 @@ class BottomSheetAction extends StatelessWidget {
   final Widget? child;
   final bool enabled;
   final String? subTitle;
+  final bool showCheck;
   final VoidCallback? onTap;
 
   const BottomSheetAction({
@@ -67,6 +71,7 @@ class BottomSheetAction extends StatelessWidget {
     this.icon,
     required this.title,
     this.enabled = true,
+    this.showCheck = false,
     this.child,
     this.subTitle,
     this.onTap,
@@ -105,6 +110,16 @@ class BottomSheetAction extends StatelessWidget {
                     ),
                   ],
                 ],
+              ),
+            ),
+            Visibility(
+              visible: showCheck,
+              child: SvgPicture.asset(
+                Assets.images.icCheck,
+                colorFilter: ColorFilter.mode(
+                  context.colorScheme.primary,
+                  BlendMode.srcATop,
+                ),
               ),
             ),
             Visibility(

--- a/khelo/lib/ui/flow/matches/match_detail/components/match_detail_highlight_view.dart
+++ b/khelo/lib/ui/flow/matches/match_detail/components/match_detail_highlight_view.dart
@@ -3,7 +3,6 @@ import 'package:data/api/ball_score/ball_score_model.dart';
 import 'package:data/api/match/match_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:khelo/components/action_bottom_sheet.dart';
 import 'package:khelo/components/empty_screen.dart';
@@ -14,8 +13,6 @@ import 'package:khelo/ui/flow/matches/match_detail/match_detail_tab_view_model.d
 import 'package:style/extensions/context_extensions.dart';
 import 'package:style/indicator/progress_indicator.dart';
 import 'package:style/widgets/adaptive_outlined_tile.dart';
-
-import '../../../../../gen/assets.gen.dart';
 
 class MatchDetailHighlightView extends ConsumerWidget {
   const MatchDetailHighlightView({super.key});
@@ -181,10 +178,7 @@ class MatchDetailHighlightView extends ConsumerWidget {
             .map((option) => BottomSheetAction(
                   title: option.getString(context),
                   enabled: highlightFilterOption != option,
-                  child: _checkWidget(
-                    context,
-                    isShowCheck: highlightFilterOption == option,
-                  ),
+                  showCheck: highlightFilterOption == option,
                   onTap: () {
                     context.pop();
                     onTap(option);
@@ -205,10 +199,7 @@ class MatchDetailHighlightView extends ConsumerWidget {
               ?.map((match) => BottomSheetAction(
                     title: match.team.name,
                     enabled: highlightTeamId != match.team.id,
-                    child: _checkWidget(
-                      context,
-                      isShowCheck: highlightTeamId == match.team.id,
-                    ),
+                    showCheck: highlightTeamId == match.team.id,
                     onTap: () {
                       context.pop();
                       onTap(match.team.id);
@@ -218,18 +209,4 @@ class MatchDetailHighlightView extends ConsumerWidget {
           [],
     );
   }
-
-  Widget? _checkWidget(
-    BuildContext context, {
-    required bool isShowCheck,
-  }) =>
-      isShowCheck
-          ? SvgPicture.asset(
-              Assets.images.icCheck,
-              colorFilter: ColorFilter.mode(
-                context.colorScheme.primary,
-                BlendMode.srcATop,
-              ),
-            )
-          : null;
 }

--- a/khelo/lib/ui/flow/tournament/detail/components/filter_tab_view.dart
+++ b/khelo/lib/ui/flow/tournament/detail/components/filter_tab_view.dart
@@ -8,7 +8,7 @@ import '../../../../../gen/assets.gen.dart';
 class FilterTabView extends StatelessWidget {
   final String title;
   final String filterValue;
-  final Function() onFilter;
+  final VoidCallback onFilter;
 
   const FilterTabView({
     super.key,

--- a/khelo/lib/ui/flow/tournament/detail/components/filter_tab_view.dart
+++ b/khelo/lib/ui/flow/tournament/detail/components/filter_tab_view.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:style/extensions/context_extensions.dart';
+import 'package:style/text/app_text_style.dart';
+
+import '../../../../../gen/assets.gen.dart';
+
+class FilterTabView extends StatelessWidget {
+  final String title;
+  final String filterValue;
+  final Function() onFilter;
+
+  const FilterTabView({
+    super.key,
+    required this.title,
+    required this.onFilter,
+    required this.filterValue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          title,
+          style: AppTextStyle.header4.copyWith(
+            color: context.colorScheme.textPrimary,
+          ),
+        ),
+        TextButton.icon(
+          iconAlignment: IconAlignment.end,
+          onPressed: onFilter,
+          label: Text(
+            filterValue,
+            style: AppTextStyle.body2.copyWith(
+              color: context.colorScheme.primary,
+            ),
+          ),
+          icon: SvgPicture.asset(
+            Assets.images.icArrowDown,
+            height: 18,
+            width: 18,
+            colorFilter: ColorFilter.mode(
+              context.colorScheme.primary,
+              BlendMode.srcATop,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_matches_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_matches_tab.dart
@@ -2,31 +2,25 @@ import 'package:data/api/match/match_model.dart';
 import 'package:data/api/team/team_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:khelo/components/match_detail_cell.dart';
 import 'package:khelo/domain/extensions/context_extensions.dart';
 import 'package:khelo/ui/app_route.dart';
+import 'package:khelo/ui/flow/tournament/detail/components/filter_tab_view.dart';
 import 'package:style/button/bottom_sticky_overlay.dart';
 import 'package:style/button/primary_button.dart';
 import 'package:style/extensions/context_extensions.dart';
-import 'package:style/text/app_text_style.dart';
 
 import '../../../../../components/action_bottom_sheet.dart';
 import '../../../../../components/empty_screen.dart';
-import '../../../../../gen/assets.gen.dart';
 import '../tournament_detail_view_model.dart';
 
 class TournamentDetailMatchesTab extends ConsumerWidget {
-  final List<TeamModel> teams;
-  final List<MatchModel> filteredMatches;
   final Function(String) onMatchFilter;
   final Function(List<MatchModel>) onSelected;
 
   const TournamentDetailMatchesTab({
     super.key,
-    required this.teams,
-    required this.filteredMatches,
     required this.onMatchFilter,
     required this.onSelected,
   });
@@ -34,7 +28,8 @@ class TournamentDetailMatchesTab extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(tournamentDetailStateProvider);
-    if (filteredMatches.isEmpty) {
+
+    if (state.filteredMatches.isEmpty) {
       return Stack(
         children: [
           EmptyScreen(
@@ -52,8 +47,18 @@ class TournamentDetailMatchesTab extends ConsumerWidget {
       padding: context.mediaQueryPadding.copyWith(top: 0) +
           EdgeInsets.all(16).copyWith(bottom: 24),
       children: [
-        _filterView(context, state),
-        ...filteredMatches.map(
+        FilterTabView(
+          title: context.l10n.tournament_detail_matches_filter_by_teams_title,
+          onFilter: () => showFilterOptionSelectionSheet(
+            context,
+            matchFilter: state.matchFilter,
+            teams: state.tournament!.teams,
+            onTap: onMatchFilter,
+          ),
+          filterValue: state.matchFilter ??
+              context.l10n.tournament_detail_matches_filter_all_teams_option,
+        ),
+        ...state.filteredMatches.map(
           (match) {
             return Padding(
               padding: const EdgeInsets.symmetric(vertical: 8.0),
@@ -70,48 +75,11 @@ class TournamentDetailMatchesTab extends ConsumerWidget {
     );
   }
 
-  Widget _filterView(BuildContext context, TournamentDetailState state) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Text(
-          context.l10n.tournament_detail_matches_filter_by_teams_title,
-          style: AppTextStyle.header4.copyWith(
-            color: context.colorScheme.textPrimary,
-          ),
-        ),
-        TextButton.icon(
-          iconAlignment: IconAlignment.end,
-          onPressed: () => showFilterOptionSelectionSheet(
-            context,
-            matchFilter: state.matchFilter,
-            onTap: onMatchFilter,
-          ),
-          label: Text(
-            state.matchFilter ??
-                context.l10n.tournament_detail_matches_filter_all_teams_option,
-            style: AppTextStyle.body2.copyWith(
-              color: context.colorScheme.primary,
-            ),
-          ),
-          icon: SvgPicture.asset(
-            Assets.images.icArrowDown,
-            height: 18,
-            width: 18,
-            colorFilter: ColorFilter.mode(
-              context.colorScheme.primary,
-              BlendMode.srcATop,
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
   void showFilterOptionSelectionSheet(
     BuildContext context, {
     required Function(String) onTap,
     String? matchFilter,
+    required List<TeamModel> teams,
   }) async {
     final filterOptions = [
       context.l10n.tournament_detail_matches_filter_all_teams_option,
@@ -124,10 +92,7 @@ class TournamentDetailMatchesTab extends ConsumerWidget {
             .map((option) => BottomSheetAction(
                   title: option,
                   enabled: matchFiltered != option,
-                  child: _checkWidget(
-                    context,
-                    isShowCheck: matchFiltered == option,
-                  ),
+                  showCheck: matchFiltered == option,
                   onTap: () {
                     context.pop();
                     onTap(option);
@@ -135,20 +100,6 @@ class TournamentDetailMatchesTab extends ConsumerWidget {
                 ))
             .toList());
   }
-
-  Widget? _checkWidget(
-    BuildContext context, {
-    required bool isShowCheck,
-  }) =>
-      isShowCheck
-          ? SvgPicture.asset(
-              Assets.images.icCheck,
-              colorFilter: ColorFilter.mode(
-                context.colorScheme.primary,
-                BlendMode.srcATop,
-              ),
-            )
-          : null;
 
   Widget _stickyButton(BuildContext context) {
     return BottomStickyOverlay(

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_overview_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_overview_tab.dart
@@ -17,10 +17,12 @@ import '../../../../../components/image_avatar.dart';
 
 class TournamentDetailOverviewTab extends ConsumerStatefulWidget {
   final TournamentModel tournament;
+  final PageController controller;
 
   const TournamentDetailOverviewTab({
     super.key,
     required this.tournament,
+    required this.controller,
   });
 
   @override
@@ -234,6 +236,7 @@ class _TournamentDetailOverviewTabState
                       style: AppTextStyle.caption.copyWith(
                         color: context.colorScheme.textDisabled,
                       ),
+                      overflow: TextOverflow.ellipsis,
                     )
                   ],
                 ),

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_stats_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_stats_tab.dart
@@ -1,0 +1,215 @@
+import 'package:data/api/match/match_model.dart';
+import 'package:data/api/tournament/tournament_model.dart';
+import 'package:data/api/user/user_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:khelo/domain/extensions/context_extensions.dart';
+import 'package:khelo/domain/extensions/enum_extensions.dart';
+import 'package:style/extensions/context_extensions.dart';
+import 'package:style/text/app_text_style.dart';
+
+import '../../../../../components/action_bottom_sheet.dart';
+import '../../../../../components/empty_screen.dart';
+import '../../../../../components/image_avatar.dart';
+import '../components/filter_tab_view.dart';
+import '../tournament_detail_view_model.dart';
+
+class TournamentDetailStatsTab extends ConsumerWidget {
+  final Function(KeyStatTag) onFiltered;
+
+  const TournamentDetailStatsTab({
+    super.key,
+    required this.onFiltered,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(tournamentDetailStateProvider);
+
+    if (state.tournament!.keyStats.isEmpty && state.filteredStats.isEmpty) {
+      return EmptyScreen(
+        title: context.l10n.tournament_detail_stats_empty_title,
+        description: context.l10n.tournament_detail_stats_empty_description,
+        isShowButton: false,
+      );
+    }
+
+    return ListView(
+      padding: context.mediaQueryPadding.copyWith(top: 0) +
+          EdgeInsets.all(16).copyWith(bottom: 24),
+      children: [
+        FilterTabView(
+          title: context.l10n.tournament_detail_stats_tab,
+          onFilter: () => showFilterOptionSelectionSheet(
+            context,
+            keyStatFilter: state.statFilter,
+            onTap: onFiltered,
+          ),
+          filterValue: state.statFilter.getString(context),
+        ),
+        const SizedBox(height: 16),
+        if (state.filteredStats.isNotEmpty) ...[
+          _playerStatsView(context, state),
+        ] else ...[
+          SizedBox(
+            height: context.mediaQuerySize.height / 2.5,
+            child: EmptyScreen(
+              title: context.l10n.tournament_detail_stats_empty_filter_title,
+              description:
+                  context.l10n.tournament_detail_stats_empty_filter_description,
+              isShowButton: false,
+            ),
+          )
+        ],
+      ],
+    );
+  }
+
+  Widget _playerStatsView(BuildContext context, TournamentDetailState state) {
+    final headers = [
+      context.l10n.tournament_detail_stats_player_title,
+      context.l10n.tournament_detail_stats_m_title,
+      context.l10n.tournament_detail_stats_avg_title,
+      context.l10n.tournament_detail_stats_runs_title,
+    ];
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(16),
+      child: DataTable(
+          columnSpacing: 8,
+          headingRowHeight: 40,
+          horizontalMargin: 16,
+          dataRowMaxHeight: 74,
+          decoration: BoxDecoration(color: context.colorScheme.containerHigh),
+          dataRowColor: WidgetStateProperty.all(context.colorScheme.surface),
+          columns: headers
+              .map((title) => _dataColumn(
+                    context,
+                    title: title,
+                    width: (title == headers.first)
+                        ? context.mediaQuerySize.width * 0.45
+                        : context.mediaQuerySize.width * 0.1,
+                  ))
+              .toList(),
+          rows: state.filteredStats
+              .map((e) => _dataRow(
+                    context,
+                    e,
+                    state.tournament!.matches,
+                  ))
+              .toList()),
+    );
+  }
+
+  DataColumn _dataColumn(
+    BuildContext context, {
+    required String title,
+    required double width,
+  }) {
+    return DataColumn(
+        label: SizedBox(
+      width: width,
+      child: Text(
+        title,
+        style: AppTextStyle.body2.copyWith(
+          color: context.colorScheme.textPrimary,
+        ),
+      ),
+    ));
+  }
+
+  DataRow _dataRow(
+    BuildContext context,
+    PlayerKeyStat keyStat,
+    List<MatchModel> matches,
+  ) {
+    final matchCount = matches
+        .where((element) => element.players.contains(keyStat.player.id))
+        .length;
+    final average =
+        keyStat.stats.bowlingStat?.average.toStringAsFixed(1) ?? '0.0';
+    final runs = keyStat.stats.battingStat?.runScored.toString() ?? '0';
+
+    return DataRow(
+      cells: [
+        _playerProfileDataCell(context, keyStat.player),
+        _dataCell(context, text: matchCount.toString()),
+        _dataCell(context, text: average),
+        _dataCell(
+          context,
+          text: runs,
+          textColor: context.colorScheme.textPrimary,
+        ),
+      ],
+    );
+  }
+
+  DataCell _playerProfileDataCell(BuildContext context, UserModel player) {
+    return DataCell(
+      Row(
+        children: [
+          ImageAvatar(
+            size: 40,
+            initial: player.nameInitial,
+            imageUrl: player.profile_img_url,
+          ),
+          const SizedBox(width: 16),
+          Flexible(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  player.name ?? '',
+                  style: AppTextStyle.body1.copyWith(
+                    color: context.colorScheme.textPrimary,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (player.player_role != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    player.player_role!.getString(context),
+                    style: AppTextStyle.caption
+                        .copyWith(color: context.colorScheme.textSecondary),
+                  )
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  DataCell _dataCell(BuildContext context,
+      {required String text, Color? textColor}) {
+    return DataCell(Text(
+      text,
+      style: AppTextStyle.caption.copyWith(
+        color: textColor ?? context.colorScheme.textDisabled,
+      ),
+    ));
+  }
+
+  void showFilterOptionSelectionSheet(
+    BuildContext context, {
+    required Function(KeyStatTag) onTap,
+    KeyStatTag? keyStatFilter,
+  }) async {
+    return await showActionBottomSheet(
+        context: context,
+        items: KeyStatTag.values
+            .map((option) => BottomSheetAction(
+                  title: option.getString(context),
+                  enabled: keyStatFilter != option,
+                  showCheck: keyStatFilter == option,
+                  onTap: () {
+                    context.pop();
+                    onTap(option);
+                  },
+                ))
+            .toList());
+  }
+}

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
@@ -143,6 +143,7 @@ class _TournamentDetailScreenState
             onMatchFilter: notifier.onMatchFilter,
             onSelected: notifier.onMatchesSelected,
           ),
+          //Temporary tab
           Container(),
           TournamentDetailStatsTab(
             onFiltered: notifier.onStatFilter,

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_screen.dart
@@ -10,6 +10,7 @@ import 'package:khelo/domain/formatter/date_formatter.dart';
 import 'package:khelo/ui/flow/tournament/components/sliver_header_delegate.dart';
 import 'package:khelo/ui/flow/tournament/detail/tabs/tournament_detail_matches_tab.dart';
 import 'package:khelo/ui/flow/tournament/detail/tabs/tournament_detail_overview_tab.dart';
+import 'package:khelo/ui/flow/tournament/detail/tabs/tournament_detail_stats_tab.dart';
 import 'package:khelo/ui/flow/tournament/detail/tabs/tournament_detail_teams_tab.dart';
 import 'package:khelo/ui/flow/tournament/detail/tournament_detail_view_model.dart';
 import 'package:style/button/more_option_button.dart';
@@ -132,16 +133,19 @@ class _TournamentDetailScreenState
         children: [
           TournamentDetailOverviewTab(
             tournament: state.tournament!,
+            controller: _controller,
           ),
           TournamentDetailTeamsTab(
             teams: state.tournament?.teams ?? [],
             onSelected: notifier.onTeamsSelected,
           ),
           TournamentDetailMatchesTab(
-            teams: state.tournament!.teams,
-            filteredMatches: state.filteredMatches,
             onMatchFilter: notifier.onMatchFilter,
             onSelected: notifier.onMatchesSelected,
+          ),
+          Container(),
+          TournamentDetailStatsTab(
+            onFiltered: notifier.onStatFilter,
           ),
         ],
       ),

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.dart
@@ -42,6 +42,7 @@ class TournamentDetailStateViewNotifier
         .listen((tournament) {
       state = state.copyWith(tournament: tournament, loading: false);
       onMatchFilter(null);
+      onStatFilter(null);
     }, onError: (e) {
       state = state.copyWith(error: e, loading: false);
       debugPrint(
@@ -104,6 +105,16 @@ class TournamentDetailStateViewNotifier
     }
   }
 
+  void onStatFilter(KeyStatTag? tag) {
+    if (state.tournament == null) return;
+
+    final filteredStats = state.tournament!.keyStats
+        .where((element) => element.tag == (tag ?? state.statFilter))
+        .toList();
+    state = state.copyWith(
+        filteredStats: filteredStats, statFilter: tag ?? state.statFilter);
+  }
+
   @override
   void dispose() {
     _tournamentSubscription?.cancel();
@@ -121,5 +132,7 @@ class TournamentDetailState with _$TournamentDetailState {
     Object? actionError,
     @Default(null) String? matchFilter,
     @Default([]) List<MatchModel> filteredMatches,
+    @Default(KeyStatTag.mostRuns) KeyStatTag statFilter,
+    @Default([]) List<PlayerKeyStat> filteredStats,
   }) = _TournamentDetailState;
 }

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.freezed.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.freezed.dart
@@ -23,6 +23,8 @@ mixin _$TournamentDetailState {
   Object? get actionError => throw _privateConstructorUsedError;
   String? get matchFilter => throw _privateConstructorUsedError;
   List<MatchModel> get filteredMatches => throw _privateConstructorUsedError;
+  KeyStatTag get statFilter => throw _privateConstructorUsedError;
+  List<PlayerKeyStat> get filteredStats => throw _privateConstructorUsedError;
 
   /// Create a copy of TournamentDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -44,7 +46,9 @@ abstract class $TournamentDetailStateCopyWith<$Res> {
       Object? error,
       Object? actionError,
       String? matchFilter,
-      List<MatchModel> filteredMatches});
+      List<MatchModel> filteredMatches,
+      KeyStatTag statFilter,
+      List<PlayerKeyStat> filteredStats});
 
   $TournamentModelCopyWith<$Res>? get tournament;
 }
@@ -72,6 +76,8 @@ class _$TournamentDetailStateCopyWithImpl<$Res,
     Object? actionError = freezed,
     Object? matchFilter = freezed,
     Object? filteredMatches = null,
+    Object? statFilter = null,
+    Object? filteredStats = null,
   }) {
     return _then(_value.copyWith(
       tournament: freezed == tournament
@@ -96,6 +102,14 @@ class _$TournamentDetailStateCopyWithImpl<$Res,
           ? _value.filteredMatches
           : filteredMatches // ignore: cast_nullable_to_non_nullable
               as List<MatchModel>,
+      statFilter: null == statFilter
+          ? _value.statFilter
+          : statFilter // ignore: cast_nullable_to_non_nullable
+              as KeyStatTag,
+      filteredStats: null == filteredStats
+          ? _value.filteredStats
+          : filteredStats // ignore: cast_nullable_to_non_nullable
+              as List<PlayerKeyStat>,
     ) as $Val);
   }
 
@@ -130,7 +144,9 @@ abstract class _$$TournamentDetailStateImplCopyWith<$Res>
       Object? error,
       Object? actionError,
       String? matchFilter,
-      List<MatchModel> filteredMatches});
+      List<MatchModel> filteredMatches,
+      KeyStatTag statFilter,
+      List<PlayerKeyStat> filteredStats});
 
   @override
   $TournamentModelCopyWith<$Res>? get tournament;
@@ -157,6 +173,8 @@ class __$$TournamentDetailStateImplCopyWithImpl<$Res>
     Object? actionError = freezed,
     Object? matchFilter = freezed,
     Object? filteredMatches = null,
+    Object? statFilter = null,
+    Object? filteredStats = null,
   }) {
     return _then(_$TournamentDetailStateImpl(
       tournament: freezed == tournament
@@ -181,6 +199,14 @@ class __$$TournamentDetailStateImplCopyWithImpl<$Res>
           ? _value._filteredMatches
           : filteredMatches // ignore: cast_nullable_to_non_nullable
               as List<MatchModel>,
+      statFilter: null == statFilter
+          ? _value.statFilter
+          : statFilter // ignore: cast_nullable_to_non_nullable
+              as KeyStatTag,
+      filteredStats: null == filteredStats
+          ? _value._filteredStats
+          : filteredStats // ignore: cast_nullable_to_non_nullable
+              as List<PlayerKeyStat>,
     ));
   }
 }
@@ -195,8 +221,11 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
       this.error,
       this.actionError,
       this.matchFilter = null,
-      final List<MatchModel> filteredMatches = const []})
-      : _filteredMatches = filteredMatches;
+      final List<MatchModel> filteredMatches = const [],
+      this.statFilter = KeyStatTag.mostRuns,
+      final List<PlayerKeyStat> filteredStats = const []})
+      : _filteredMatches = filteredMatches,
+        _filteredStats = filteredStats;
 
   @override
   @JsonKey()
@@ -224,8 +253,20 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
   }
 
   @override
+  @JsonKey()
+  final KeyStatTag statFilter;
+  final List<PlayerKeyStat> _filteredStats;
+  @override
+  @JsonKey()
+  List<PlayerKeyStat> get filteredStats {
+    if (_filteredStats is EqualUnmodifiableListView) return _filteredStats;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_filteredStats);
+  }
+
+  @override
   String toString() {
-    return 'TournamentDetailState(tournament: $tournament, loading: $loading, selectedTab: $selectedTab, error: $error, actionError: $actionError, matchFilter: $matchFilter, filteredMatches: $filteredMatches)';
+    return 'TournamentDetailState(tournament: $tournament, loading: $loading, selectedTab: $selectedTab, error: $error, actionError: $actionError, matchFilter: $matchFilter, filteredMatches: $filteredMatches, statFilter: $statFilter, filteredStats: $filteredStats)';
   }
 
   @override
@@ -244,7 +285,11 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
             (identical(other.matchFilter, matchFilter) ||
                 other.matchFilter == matchFilter) &&
             const DeepCollectionEquality()
-                .equals(other._filteredMatches, _filteredMatches));
+                .equals(other._filteredMatches, _filteredMatches) &&
+            (identical(other.statFilter, statFilter) ||
+                other.statFilter == statFilter) &&
+            const DeepCollectionEquality()
+                .equals(other._filteredStats, _filteredStats));
   }
 
   @override
@@ -256,7 +301,9 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
       const DeepCollectionEquality().hash(error),
       const DeepCollectionEquality().hash(actionError),
       matchFilter,
-      const DeepCollectionEquality().hash(_filteredMatches));
+      const DeepCollectionEquality().hash(_filteredMatches),
+      statFilter,
+      const DeepCollectionEquality().hash(_filteredStats));
 
   /// Create a copy of TournamentDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -276,7 +323,9 @@ abstract class _TournamentDetailState implements TournamentDetailState {
       final Object? error,
       final Object? actionError,
       final String? matchFilter,
-      final List<MatchModel> filteredMatches}) = _$TournamentDetailStateImpl;
+      final List<MatchModel> filteredMatches,
+      final KeyStatTag statFilter,
+      final List<PlayerKeyStat> filteredStats}) = _$TournamentDetailStateImpl;
 
   @override
   TournamentModel? get tournament;
@@ -292,6 +341,10 @@ abstract class _TournamentDetailState implements TournamentDetailState {
   String? get matchFilter;
   @override
   List<MatchModel> get filteredMatches;
+  @override
+  KeyStatTag get statFilter;
+  @override
+  List<PlayerKeyStat> get filteredStats;
 
   /// Create a copy of TournamentDetailState
   /// with the given fields replaced by the non-null parameter values.


### PR DESCRIPTION
- Implement tournament detail stats tab

[stats_tab.webm](https://github.com/user-attachments/assets/2f1cbcbf-99f2-4185-8851-821eb3b2ae8f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new tab for tournament statistics, enhancing user access to key stats.
	- Added a filtering UI component for tournament details, allowing users to select and view specific statistics.
	- Enhanced localization support with new text strings for tournament and player statistics.

- **Bug Fixes**
	- Improved logic to ensure only active player statistics are displayed.

- **Improvements**
	- Streamlined state management for match filtering, simplifying the user experience.
	- Enhanced text display for team names in the tournament overview to handle long names better.
	- Added a checkmark indicator in the bottom sheet for selected options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->