### PR TITLE
Implement tournament update/delete option

### DIFF
--- a/data/lib/service/tournament/tournament_service.dart
+++ b/data/lib/service/tournament/tournament_service.dart
@@ -172,4 +172,12 @@ class TournamentService {
       throw AppError.fromError(error, stack);
     }
   }
+
+  Future<void> deleteTournament(String tournamentId) async {
+    try {
+      await _tournamentCollection.doc(tournamentId).delete();
+    } catch (error, stack) {
+      throw AppError.fromError(error, stack);
+    }
+  }
 }

--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -19,6 +19,7 @@
   "common_submit_title": "Submit",
   "common_not_now": "Not now",
   "common_create": "Create",
+  "common_edit": "Edit",
   "common_not_specified_title": "Not Specified",
   "common_runs_title": "{count, plural, =0{{count} runs} =1{{count} run} other{{count} runs}}",
   "@common_runs_title": {
@@ -168,6 +169,8 @@
   "add_tournament_match_selection": "Match selection",
   "add_tournament_edit_banner": "Edit banner",
   "add_tournament_add_banner_placeholder": "Add banner image",
+  "add_tournament_delete_title": "Delete tournament!",
+  "add_tournament_delete_description": "This action will permanently delete the tournament, along with all match data. Are you sure you want to delete?",
   "add_tournament_date_error": "End date should be greater than start date",
   "add_tournament_teams_title": "{count, plural, =0{No teams} =1{{count} Team} other{{count} Teams}}",
   "@add_tournament_teams_title": {
@@ -207,6 +210,8 @@
   "tournament_detail_matches_tab": "Matches",
   "tournament_detail_points_table_tab": "Points Table",
   "tournament_detail_stats_tab": "Stats",
+  "tournament_detail_edit_title": "Edit tournament",
+  "tournament_detail_members_title": "Members",
 
   "tournament_detail_overview_info_title": "Tournament info",
   "tournament_detail_overview_name_title": "Tournament Name",

--- a/khelo/lib/ui/app_route.dart
+++ b/khelo/lib/ui/app_route.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:data/api/match/match_model.dart';
 import 'package:data/api/team/team_model.dart';
+import 'package:data/api/tournament/tournament_model.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -172,9 +173,9 @@ class AppRoute {
         ),
       );
 
-  static AppRoute addTournament() => AppRoute(
+  static AppRoute addTournament({TournamentModel? editTournament}) => AppRoute(
         pathAddTournament,
-        builder: (_) => const AddTournamentScreen(),
+        builder: (_) => AddTournamentScreen(editTournament: editTournament),
       );
 
   static AppRoute teamSelection({List<TeamModel>? selectedTeams}) => AppRoute(
@@ -183,9 +184,9 @@ class AppRoute {
       );
 
   static AppRoute tournamentDetail({required String tournamentId}) => AppRoute(
-    pathTournamentDetail,
-    builder: (_) => TournamentDetailScreen(tournamentId: tournamentId),
-  );
+        pathTournamentDetail,
+        builder: (_) => TournamentDetailScreen(tournamentId: tournamentId),
+      );
 
   static AppRoute matchDetailTab({required String matchId}) => AppRoute(
         pathMatchDetailTab,

--- a/khelo/lib/ui/flow/tournament/add/add_tournament_screen.dart
+++ b/khelo/lib/ui/flow/tournament/add/add_tournament_screen.dart
@@ -10,10 +10,12 @@ import 'package:go_router/go_router.dart';
 import 'package:khelo/components/profile_image_avatar.dart';
 import 'package:khelo/domain/extensions/context_extensions.dart';
 import 'package:khelo/domain/extensions/enum_extensions.dart';
+import 'package:khelo/domain/extensions/widget_extension.dart';
 import 'package:khelo/gen/assets.gen.dart';
 import 'package:khelo/ui/app_route.dart';
 import 'package:khelo/ui/flow/tournament/add/add_tournament_view_model.dart';
 import 'package:style/animations/on_tap_scale.dart';
+import 'package:style/button/action_button.dart';
 import 'package:style/button/bottom_sticky_overlay.dart';
 import 'package:style/button/primary_button.dart';
 import 'package:style/extensions/context_extensions.dart';
@@ -25,12 +27,15 @@ import 'package:style/widgets/adaptive_outlined_tile.dart';
 
 import '../../../../components/action_bottom_sheet.dart';
 import '../../../../components/app_page.dart';
+import '../../../../components/confirmation_dialog.dart';
 import '../../../../components/error_snackbar.dart';
 import '../../../../components/image_picker_sheet.dart';
 import '../../../../domain/formatter/date_formatter.dart';
 
 class AddTournamentScreen extends ConsumerStatefulWidget {
-  const AddTournamentScreen({super.key});
+  final TournamentModel? editTournament;
+
+  const AddTournamentScreen({super.key, this.editTournament});
 
   @override
   ConsumerState<AddTournamentScreen> createState() =>
@@ -44,6 +49,7 @@ class _AddTournamentScreenState extends ConsumerState<AddTournamentScreen> {
   void initState() {
     super.initState();
     notifier = ref.read(addTournamentStateProvider.notifier);
+    runPostFrame(() => notifier.setData(widget.editTournament));
   }
 
   void _observeActionError(BuildContext context, WidgetRef ref) {
@@ -80,13 +86,45 @@ class _AddTournamentScreenState extends ConsumerState<AddTournamentScreen> {
     _observePop(context, ref);
 
     final state = ref.watch(addTournamentStateProvider);
+    final isOrganizer = widget.editTournament == null ||
+        (state.currentUserId == widget.editTournament?.created_by ||
+            widget.editTournament!.members
+                .any((e) => e.id == state.currentUserId && e.role.isOrganizer));
 
     return AppPage(
-      title: context.l10n.add_tournament_screen_title,
+      title: widget.editTournament == null
+          ? context.l10n.add_tournament_screen_title
+          : context.l10n.tournament_detail_edit_title,
+      actions: isOrganizer
+          ? [
+              actionButton(
+                context,
+                onPressed: () => showConfirmationDialog(
+                  context,
+                  title: context.l10n.add_tournament_delete_title,
+                  message: context.l10n.add_tournament_delete_description,
+                  confirmBtnText: context.l10n.common_delete_title,
+                  onConfirm: () {
+                    notifier.deleteTournament();
+                    context.pop();
+                    context.pop();
+                  },
+                ),
+                icon: SvgPicture.asset(
+                  Assets.images.icBin,
+                  height: 24,
+                  width: 24,
+                  fit: BoxFit.contain,
+                  colorFilter: ColorFilter.mode(
+                      context.colorScheme.alert, BlendMode.srcATop),
+                ),
+              )
+            ]
+          : null,
       body: Builder(
         builder: (context) => Stack(
           children: [
-            _body(context, state),
+            _body(context, isOrganizer, state),
             _stickyButton(context, state),
           ],
         ),
@@ -94,7 +132,8 @@ class _AddTournamentScreenState extends ConsumerState<AddTournamentScreen> {
     );
   }
 
-  Widget _body(BuildContext context, AddTournamentState state) {
+  Widget _body(
+      BuildContext context, bool isOrganizer, AddTournamentState state) {
     return ListView(
       padding: context.mediaQueryPadding + BottomStickyOverlay.padding,
       children: [
@@ -105,6 +144,7 @@ class _AddTournamentScreenState extends ConsumerState<AddTournamentScreen> {
             children: [
               AppTextField(
                 controller: state.nameController,
+                enabled: isOrganizer,
                 label: context.l10n.add_tournament_name,
                 onChanged: (_) => notifier.onChange(),
                 contentPadding:
@@ -122,6 +162,7 @@ class _AddTournamentScreenState extends ConsumerState<AddTournamentScreen> {
                 headerText: context.l10n.add_tournament_type,
                 title: state.selectedType.getString(context),
                 showTrailingIcon: true,
+                enabled: isOrganizer,
                 onTap: () {
                   _selectTypeSheet(
                     context,
@@ -279,7 +320,9 @@ class _AddTournamentScreenState extends ConsumerState<AddTournamentScreen> {
   ) {
     return BottomStickyOverlay(
       child: PrimaryButton(
-        context.l10n.common_create,
+        widget.editTournament == null
+            ? context.l10n.common_create
+            : context.l10n.common_edit,
         progress: state.loading,
         enabled: state.enableButton,
         onPressed: notifier.addTournament,

--- a/khelo/lib/ui/flow/tournament/add/add_tournament_view_model.dart
+++ b/khelo/lib/ui/flow/tournament/add/add_tournament_view_model.dart
@@ -70,7 +70,6 @@ class AddTournamentViewNotifier extends StateNotifier<AddTournamentState> {
       state = state.copyWith(
         imageUploading: true,
         actionError: null,
-        enableButton: _editedTournament != null,
       );
       if (await File(imagePath).isFileUnderMaxSize()) {
         isBanner
@@ -83,6 +82,7 @@ class AddTournamentViewNotifier extends StateNotifier<AddTournamentState> {
             imageUploading: false,
             actionError: const LargeAttachmentUploadError());
       }
+      onChange();
     } catch (e) {
       state = state.copyWith(imageUploading: false, actionError: e);
       debugPrint("AddTournamentViewNotifier: error while image upload -> $e");
@@ -93,11 +93,14 @@ class AddTournamentViewNotifier extends StateNotifier<AddTournamentState> {
     final name = state.nameController.text.trim();
 
     state = state.copyWith(
-      enableButton: name.isNotEmpty && _editedTournament?.name != name ||
-          _editedTournament?.type != state.selectedType ||
-          _editedTournament?.start_date != state.startDate ||
-          _editedTournament?.end_date != state.endDate ||
-          _editedTournament?.teams != state.teams,
+      enableButton: name.isNotEmpty &&
+          (_editedTournament?.name != name ||
+              _editedTournament?.type != state.selectedType ||
+              _editedTournament?.start_date != state.startDate ||
+              _editedTournament?.end_date != state.endDate ||
+              _editedTournament?.teams != state.teams ||
+              state.profilePath != null ||
+              state.bannerPath != null),
     );
   }
 

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_matches_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_matches_tab.dart
@@ -7,8 +7,7 @@ import 'package:khelo/components/match_detail_cell.dart';
 import 'package:khelo/domain/extensions/context_extensions.dart';
 import 'package:khelo/ui/app_route.dart';
 import 'package:khelo/ui/flow/tournament/detail/components/filter_tab_view.dart';
-import 'package:style/button/bottom_sticky_overlay.dart';
-import 'package:style/button/primary_button.dart';
+
 import 'package:style/extensions/context_extensions.dart';
 
 import '../../../../../components/action_bottom_sheet.dart';
@@ -30,16 +29,16 @@ class TournamentDetailMatchesTab extends ConsumerWidget {
     final state = ref.watch(tournamentDetailStateProvider);
 
     if (state.filteredMatches.isEmpty) {
-      return Stack(
-        children: [
-          EmptyScreen(
-            title: context.l10n.tournament_detail_matches_empty_title,
-            description:
-                context.l10n.tournament_detail_matches_empty_description,
-            isShowButton: false,
-          ),
-          _stickyButton(context),
-        ],
+      return EmptyScreen(
+        title: context.l10n.tournament_detail_matches_empty_title,
+        description: context.l10n.tournament_detail_matches_empty_description,
+        buttonTitle: context.l10n.tournament_detail_matches_add_btn,
+        isShowButton: state.tournament!.created_by == state.currentUserId ||
+            state.tournament!.members
+                .any((element) => element.id == state.currentUserId),
+        onTap: () {
+          onSelected.call([]);
+        },
       );
     }
 
@@ -99,16 +98,5 @@ class TournamentDetailMatchesTab extends ConsumerWidget {
                   },
                 ))
             .toList());
-  }
-
-  Widget _stickyButton(BuildContext context) {
-    return BottomStickyOverlay(
-      child: PrimaryButton(
-        context.l10n.tournament_detail_matches_add_btn,
-        onPressed: () {
-          onSelected.call([]);
-        },
-      ),
-    );
   }
 }

--- a/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_teams_tab.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tabs/tournament_detail_teams_tab.dart
@@ -25,7 +25,7 @@ class TournamentDetailTeamsTab extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(tournamentDetailStateProvider);
-    if (state.tournament!.teams.isNotEmpty) {
+    if (state.tournament!.teams.isEmpty) {
       return EmptyScreen(
         title: context.l10n.tournament_detail_teams_empty_title,
         description: context.l10n.tournament_detail_teams_empty_description,

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.dart
@@ -4,6 +4,7 @@ import 'package:data/api/match/match_model.dart';
 import 'package:data/api/team/team_model.dart';
 import 'package:data/api/tournament/tournament_model.dart';
 import 'package:data/service/tournament/tournament_service.dart';
+import 'package:data/storage/app_preferences.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -12,8 +13,10 @@ part 'tournament_detail_view_model.freezed.dart';
 
 final tournamentDetailStateProvider = StateNotifierProvider.autoDispose<
     TournamentDetailStateViewNotifier, TournamentDetailState>(
-  (ref) =>
-      TournamentDetailStateViewNotifier(ref.read(tournamentServiceProvider)),
+  (ref) => TournamentDetailStateViewNotifier(
+    ref.read(tournamentServiceProvider),
+    ref.read(currentUserPod)?.id,
+  ),
 );
 
 class TournamentDetailStateViewNotifier
@@ -21,8 +24,10 @@ class TournamentDetailStateViewNotifier
   final TournamentService _tournamentService;
   StreamSubscription? _tournamentSubscription;
 
-  TournamentDetailStateViewNotifier(this._tournamentService)
-      : super(const TournamentDetailState());
+  TournamentDetailStateViewNotifier(
+    this._tournamentService,
+    String? userId,
+  ) : super(TournamentDetailState(currentUserId: userId));
 
   String? _tournamentId;
 
@@ -222,6 +227,7 @@ class TournamentDetailState with _$TournamentDetailState {
     @Default(0) int selectedTab,
     Object? error,
     Object? actionError,
+    String? currentUserId,
     @Default(null) String? matchFilter,
     @Default([]) List<MatchModel> filteredMatches,
     @Default(KeyStatTag.mostRuns) KeyStatTag statFilter,

--- a/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.freezed.dart
+++ b/khelo/lib/ui/flow/tournament/detail/tournament_detail_view_model.freezed.dart
@@ -21,6 +21,7 @@ mixin _$TournamentDetailState {
   int get selectedTab => throw _privateConstructorUsedError;
   Object? get error => throw _privateConstructorUsedError;
   Object? get actionError => throw _privateConstructorUsedError;
+  String? get currentUserId => throw _privateConstructorUsedError;
   String? get matchFilter => throw _privateConstructorUsedError;
   List<MatchModel> get filteredMatches => throw _privateConstructorUsedError;
   KeyStatTag get statFilter => throw _privateConstructorUsedError;
@@ -46,6 +47,7 @@ abstract class $TournamentDetailStateCopyWith<$Res> {
       int selectedTab,
       Object? error,
       Object? actionError,
+      String? currentUserId,
       String? matchFilter,
       List<MatchModel> filteredMatches,
       KeyStatTag statFilter,
@@ -76,6 +78,7 @@ class _$TournamentDetailStateCopyWithImpl<$Res,
     Object? selectedTab = null,
     Object? error = freezed,
     Object? actionError = freezed,
+    Object? currentUserId = freezed,
     Object? matchFilter = freezed,
     Object? filteredMatches = null,
     Object? statFilter = null,
@@ -97,6 +100,10 @@ class _$TournamentDetailStateCopyWithImpl<$Res,
               as int,
       error: freezed == error ? _value.error : error,
       actionError: freezed == actionError ? _value.actionError : actionError,
+      currentUserId: freezed == currentUserId
+          ? _value.currentUserId
+          : currentUserId // ignore: cast_nullable_to_non_nullable
+              as String?,
       matchFilter: freezed == matchFilter
           ? _value.matchFilter
           : matchFilter // ignore: cast_nullable_to_non_nullable
@@ -150,6 +157,7 @@ abstract class _$$TournamentDetailStateImplCopyWith<$Res>
       int selectedTab,
       Object? error,
       Object? actionError,
+      String? currentUserId,
       String? matchFilter,
       List<MatchModel> filteredMatches,
       KeyStatTag statFilter,
@@ -179,6 +187,7 @@ class __$$TournamentDetailStateImplCopyWithImpl<$Res>
     Object? selectedTab = null,
     Object? error = freezed,
     Object? actionError = freezed,
+    Object? currentUserId = freezed,
     Object? matchFilter = freezed,
     Object? filteredMatches = null,
     Object? statFilter = null,
@@ -200,6 +209,10 @@ class __$$TournamentDetailStateImplCopyWithImpl<$Res>
               as int,
       error: freezed == error ? _value.error : error,
       actionError: freezed == actionError ? _value.actionError : actionError,
+      currentUserId: freezed == currentUserId
+          ? _value.currentUserId
+          : currentUserId // ignore: cast_nullable_to_non_nullable
+              as String?,
       matchFilter: freezed == matchFilter
           ? _value.matchFilter
           : matchFilter // ignore: cast_nullable_to_non_nullable
@@ -233,6 +246,7 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
       this.selectedTab = 0,
       this.error,
       this.actionError,
+      this.currentUserId,
       this.matchFilter = null,
       final List<MatchModel> filteredMatches = const [],
       this.statFilter = KeyStatTag.mostRuns,
@@ -255,6 +269,8 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
   final Object? error;
   @override
   final Object? actionError;
+  @override
+  final String? currentUserId;
   @override
   @JsonKey()
   final String? matchFilter;
@@ -290,7 +306,7 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
 
   @override
   String toString() {
-    return 'TournamentDetailState(tournament: $tournament, loading: $loading, selectedTab: $selectedTab, error: $error, actionError: $actionError, matchFilter: $matchFilter, filteredMatches: $filteredMatches, statFilter: $statFilter, filteredStats: $filteredStats, teamPoints: $teamPoints)';
+    return 'TournamentDetailState(tournament: $tournament, loading: $loading, selectedTab: $selectedTab, error: $error, actionError: $actionError, currentUserId: $currentUserId, matchFilter: $matchFilter, filteredMatches: $filteredMatches, statFilter: $statFilter, filteredStats: $filteredStats, teamPoints: $teamPoints)';
   }
 
   @override
@@ -306,6 +322,8 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
             const DeepCollectionEquality().equals(other.error, error) &&
             const DeepCollectionEquality()
                 .equals(other.actionError, actionError) &&
+            (identical(other.currentUserId, currentUserId) ||
+                other.currentUserId == currentUserId) &&
             (identical(other.matchFilter, matchFilter) ||
                 other.matchFilter == matchFilter) &&
             const DeepCollectionEquality()
@@ -326,6 +344,7 @@ class _$TournamentDetailStateImpl implements _TournamentDetailState {
       selectedTab,
       const DeepCollectionEquality().hash(error),
       const DeepCollectionEquality().hash(actionError),
+      currentUserId,
       matchFilter,
       const DeepCollectionEquality().hash(_filteredMatches),
       statFilter,
@@ -349,6 +368,7 @@ abstract class _TournamentDetailState implements TournamentDetailState {
       final int selectedTab,
       final Object? error,
       final Object? actionError,
+      final String? currentUserId,
       final String? matchFilter,
       final List<MatchModel> filteredMatches,
       final KeyStatTag statFilter,
@@ -365,6 +385,8 @@ abstract class _TournamentDetailState implements TournamentDetailState {
   Object? get error;
   @override
   Object? get actionError;
+  @override
+  String? get currentUserId;
   @override
   String? get matchFilter;
   @override

--- a/style/lib/widgets/adaptive_outlined_tile.dart
+++ b/style/lib/widgets/adaptive_outlined_tile.dart
@@ -11,6 +11,7 @@ class AdaptiveOutlinedTile extends StatelessWidget {
   final int? maxLines;
   final String placeholder;
   final bool showTrailingIcon;
+  final bool enabled;
   final String? iconImage;
   final Function()? onTap;
 
@@ -21,6 +22,7 @@ class AdaptiveOutlinedTile extends StatelessWidget {
     this.title,
     this.maxLines,
     required this.placeholder,
+    this.enabled = true,
     this.showTrailingIcon = false,
     this.iconImage,
     this.onTap,
@@ -55,6 +57,7 @@ class AdaptiveOutlinedTile extends StatelessWidget {
         ],
         OnTapScale(
           onTap: onTap,
+          enabled: enabled,
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             decoration: BoxDecoration(
@@ -73,7 +76,7 @@ class AdaptiveOutlinedTile extends StatelessWidget {
                             : context.colorScheme.textSecondary),
                   ),
                 ),
-                if (showTrailingIcon) ...[
+                if (showTrailingIcon && enabled) ...[
                   SvgPicture.asset(
                     iconImage ?? "assets/images/ic_arrow_down.svg",
                     height: 18,


### PR DESCRIPTION
- Implement tournament update/delete option
- Manage members and organizer role wise actions
- Update teams and matches add buttons

[update_delete.webm](https://github.com/user-attachments/assets/441f70e4-5966-4dc1-ba1d-d86fb63c7e2e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced tournament deletion functionality, allowing users to delete tournaments by ID.
	- Added UI elements for editing and deleting tournaments, including confirmation prompts.
	- Enhanced tournament detail screens with user-specific options for actions like selecting teams and editing tournaments.
	- Updated the `AddTournamentScreen` to support both creating and editing tournaments based on user roles.

- **Bug Fixes**
	- Improved error handling for tournament deletion and editing processes.

- **Documentation**
	- Updated localization files to include new UI strings for tournament management.

- **Refactor**
	- Streamlined tournament detail view models and state management to improve performance and clarity.

- **Style**
	- Enhanced the `AdaptiveOutlinedTile` widget for better interactivity and visual representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->