### PR TITLE
Double out match scheduling

### DIFF
--- a/data/lib/api/tournament/tournament_model.dart
+++ b/data/lib/api/tournament/tournament_model.dart
@@ -76,9 +76,7 @@ enum TournamentType {
   doubleOut(4, minTeamReq: 4),
   superOver(5, minTeamReq: 2),
   bestOf(6, minTeamReq: 2),
-  gully(7, minTeamReq: 2),
-  mixed(8, minTeamReq: 2),
-  other(9, minTeamReq: 2);
+  custom(7, minTeamReq: 2);
 
   final int value;
   final int minTeamReq;

--- a/data/lib/api/tournament/tournament_model.g.dart
+++ b/data/lib/api/tournament/tournament_model.g.dart
@@ -60,9 +60,7 @@ const _$TournamentTypeEnumMap = {
   TournamentType.doubleOut: 4,
   TournamentType.superOver: 5,
   TournamentType.bestOf: 6,
-  TournamentType.gully: 7,
-  TournamentType.mixed: 8,
-  TournamentType.other: 9,
+  TournamentType.custom: 7,
 };
 
 Value? _$JsonConverterFromJson<Json, Value>(

--- a/data/lib/service/tournament/tournament_service.dart
+++ b/data/lib/service/tournament/tournament_service.dart
@@ -186,7 +186,7 @@ class TournamentService {
           id: tournamentId,
           name: '',
           created_by: '',
-          type: TournamentType.other,
+          type: TournamentType.knockOut,
           start_date: DateTime.now(),
           end_date: DateTime.now().add(const Duration(days: 1)),
         );

--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -301,9 +301,7 @@
   "tournament_type_double_out": "Double Out",
   "tournament_type_super_over": "Super Over",
   "tournament_type_best_of": "Best Of",
-  "tournament_type_gully": "Gully",
-  "tournament_type_mixed": "Mixed",
-  "tournament_type_other": "Other",
+  "tournament_type_custom": "Custom",
 
   "tournament_type_knock_out_description": "Teams face off in a single elimination, with the loser immediately knocked out.\nMinimum {count} teams required.",
   "tournament_type_mini_robin_description": "A smaller round-robin format where each team plays once against all others.\nMinimum {count} teams required.",
@@ -311,9 +309,7 @@
   "tournament_type_double_out_description": "Teams get two chances before being knocked out, with a winners and losers bracket.\nMinimum {count} teams required.",
   "tournament_type_super_over_description": "A knockout format with a super over to decide tied matches.\nMinimum {count} teams required.",
   "tournament_type_best_of_description": "Teams play a series of matches, and the first to win the majority is the champion.\nMinimum {count} teams required.",
-  "tournament_type_gully_description": "Casual street-style cricket with short games and flexible rules.\nMinimum {count} teams required.",
-  "tournament_type_mixed_description": "Teams are randomly mixed, creating fun and unpredictable matches.\nMinimum {count} teams required.",
-  "tournament_type_other_description": "A custom format for tournaments with unique rules or structures.\nMinimum {count} teams required.",
+  "tournament_type_custom_description": "Fully flexible, create a structure that suits your needs.\nMinimum {count} teams required.",
 
   "add_team_screen_title": "Add Team",
   "add_team_edit_team_screen_title": "Edit Team",

--- a/khelo/lib/domain/extensions/enum_extensions.dart
+++ b/khelo/lib/domain/extensions/enum_extensions.dart
@@ -306,12 +306,8 @@ extension TournamentTypeString on TournamentType {
         return context.l10n.tournament_type_super_over;
       case TournamentType.bestOf:
         return context.l10n.tournament_type_best_of;
-      case TournamentType.gully:
-        return context.l10n.tournament_type_gully;
-      case TournamentType.mixed:
-        return context.l10n.tournament_type_mixed;
-      case TournamentType.other:
-        return context.l10n.tournament_type_other;
+      case TournamentType.custom:
+        return context.l10n.tournament_type_custom;
     }
   }
 
@@ -329,12 +325,8 @@ extension TournamentTypeString on TournamentType {
         return context.l10n.tournament_type_super_over_description(minTeamReq);
       case TournamentType.bestOf:
         return context.l10n.tournament_type_best_of_description(minTeamReq);
-      case TournamentType.gully:
-        return context.l10n.tournament_type_gully_description(minTeamReq);
-      case TournamentType.mixed:
-        return context.l10n.tournament_type_mixed_description(minTeamReq);
-      case TournamentType.other:
-        return context.l10n.tournament_type_other_description(minTeamReq);
+      case TournamentType.custom:
+        return context.l10n.tournament_type_custom_description(minTeamReq);
     }
   }
 }

--- a/khelo/lib/ui/flow/tournament/match_selection/match_scheduler.dart
+++ b/khelo/lib/ui/flow/tournament/match_selection/match_scheduler.dart
@@ -58,7 +58,7 @@ class MatchScheduler {
       case TournamentType.boxLeague:
         return scheduleBoxLeagueMatches();
       case TournamentType.doubleOut:
-        return scheduleDoubleEliminationMatches();
+        return scheduleDoubleOutMatches();
       case TournamentType.superOver:
         return scheduleSuperOverMatches();
       case TournamentType.bestOf:
@@ -88,7 +88,7 @@ class MatchScheduler {
         groupNumbers.forEach((number, matches) {
           removeAlreadyScheduledTeams(matches, teamPool);
 
-          final teamPairs = createTeamPairsForKnockout(teamPool);
+          final teamPairs = createKnockoutTeamPairs(teamPool);
           addMatches(matches, teamPairs, group, number);
 
           teamPool.removeWhere((team) => teamPairs
@@ -143,7 +143,7 @@ class MatchScheduler {
       rounds.forEach((number, matches) {
         removeTeamsThatReachedLimit(matches, teamPool, matchesPerTeam);
 
-        final teamPairs = createTeamPairsForRoundRobin(
+        final teamPairs = createRoundRobinTeamPairs(
             teamPool,
             matchesPerTeam,
             matches
@@ -224,7 +224,7 @@ class MatchScheduler {
           teams.addAll(teamPool.take(boxSize - teams.length + 1));
         }
 
-        final teamPairs = createTeamPairsForRoundRobin(
+        final teamPairs = createRoundRobinTeamPairs(
             teams,
             teams.length - 1,
             matches
@@ -305,7 +305,7 @@ class MatchScheduler {
     return additionalScheduledMatches;
   }
 
-  GroupedMatchMap scheduleDoubleEliminationMatches() {
+  GroupedMatchMap scheduleDoubleOutMatches() {
     final GroupedMatchMap additionalScheduledMatches = scheduledMatches;
     final teamPool = List.of(teams);
 
@@ -434,7 +434,7 @@ class MatchScheduler {
     return teamPoints;
   }
 
-  List<List<TeamModel>> createTeamPairsForRoundRobin(List<TeamModel> teamPool,
+  List<List<TeamModel>> createRoundRobinTeamPairs(List<TeamModel> teamPool,
       int matchesPerTeam, List<List<TeamModel>> scheduledMatches) {
     final List<List<TeamModel>> teamPairs = [];
 
@@ -475,7 +475,7 @@ class MatchScheduler {
     return teamPairs;
   }
 
-  List<List<TeamModel>> createTeamPairsForKnockout(List<TeamModel> teams) {
+  List<List<TeamModel>> createKnockoutTeamPairs(List<TeamModel> teams) {
     final List<TeamModel> shuffledTeams = List.from(teams)..shuffle();
     return shuffledTeams.chunked(2);
   }
@@ -591,7 +591,7 @@ class MatchScheduler {
         unFinishedMatches
             .any((element) => element.teams.map((e) => e.team).contains(team)));
 
-    final chunks = createTeamPairsForKnockout(teams);
+    final chunks = createKnockoutTeamPairs(teams);
     addMatches(matches, chunks, MatchGroup.round, isWinBracket ? 1 : 2);
     TeamModel? teamToReturn;
     if (unFinishedMatches.isEmpty && teams.length == 1) {


### PR DESCRIPTION
- schedule double out type matches.
- remove gully, mixed and other type.
- add custom type and let user schedule match as they want.
- Round 1 represents winner bracket, round 2 represents loser bracket.

https://github.com/user-attachments/assets/ba84957d-e188-486b-a81c-7dc10d54eb8c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new tournament type: "Custom," allowing for flexible tournament structures.
	- Enhanced match scheduling for custom tournaments and double elimination formats.

- **Bug Fixes**
	- Resolved handling of unsupported match types by allowing scheduling of custom matches without exceptions.

- **Documentation**
	- Updated localization files to reflect changes in tournament types and descriptions.

These updates improve user experience in tournament creation and management, providing more tailored options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->