### PR TITLE
Select team via qr code

### DIFF
--- a/khelo/assets/locales/app_en.arb
+++ b/khelo/assets/locales/app_en.arb
@@ -321,6 +321,7 @@
   "add_team_player_role_title": "Playing role",
   "add_team_player_add_via_contact_title": "Add via Contact",
   "add_team_players_text": "Players",
+  "add_team_already_added": "Team already added",
   "add_team_add_hint_text": "Added user will be shown here, tap on '+' button to add team member.",
 
   "scan_qr_code": "Scan QR code",

--- a/khelo/lib/ui/app_route.dart
+++ b/khelo/lib/ui/app_route.dart
@@ -26,6 +26,7 @@ import 'package:khelo/ui/flow/team/add_team_member/contact_selection/contact_sel
 import 'package:khelo/ui/flow/team/detail/make_admin/make_team_admin_screen.dart';
 import 'package:khelo/ui/flow/team/detail/team_detail_screen.dart';
 import 'package:khelo/ui/flow/team/scanner/scanner_screen.dart';
+import 'package:khelo/ui/flow/team/scanner/scanner_view_model.dart';
 import 'package:khelo/ui/flow/team/search_team/search_team_screen.dart';
 import 'package:khelo/ui/flow/tournament/add/add_tournament_screen.dart';
 import 'package:khelo/ui/flow/tournament/detail/members/tournament_detail_members_screen.dart';
@@ -321,13 +322,15 @@ class AppRoute {
                 showAddButton: showAddButton,
               ));
 
-  static AppRoute scannerScreen(
-          {required List<String> addedIds, bool isForTeam = false}) =>
+  static AppRoute scannerScreen({
+    required List<String> addedIds,
+    ScanTarget target = ScanTarget.player,
+  }) =>
       AppRoute(
         pathScannerScreen,
         builder: (_) => ScannerScreen(
           addedIds: addedIds,
-          isForTeam: isForTeam,
+          target: target,
         ),
       );
 

--- a/khelo/lib/ui/app_route.dart
+++ b/khelo/lib/ui/app_route.dart
@@ -210,9 +210,9 @@ class AppRoute {
       );
 
   static AppRoute matchSelection({required String tournamentId}) => AppRoute(
-    pathMatchSelection,
-    builder: (_) => MatchSelectionScreen(tournamentId: tournamentId),
-  );
+        pathMatchSelection,
+        builder: (_) => MatchSelectionScreen(tournamentId: tournamentId),
+      );
 
   static AppRoute tournamentDetail({required String tournamentId}) => AppRoute(
         pathTournamentDetail,
@@ -301,9 +301,15 @@ class AppRoute {
       pathEditProfile,
       builder: (_) => EditProfileScreen(isToCreateAccount: isToCreateAccount));
 
-  static AppRoute teamDetail({required String teamId}) =>
+  static AppRoute teamDetail({
+    required String teamId,
+    bool showAddButton = false,
+  }) =>
       AppRoute(pathTeamDetail,
-          builder: (_) => TeamDetailScreen(teamId: teamId));
+          builder: (_) => TeamDetailScreen(
+                teamId: teamId,
+                showAddButton: showAddButton,
+              ));
 
   static AppRoute userDetail({
     required String userId,
@@ -315,10 +321,14 @@ class AppRoute {
                 showAddButton: showAddButton,
               ));
 
-  static AppRoute scannerScreen({required List<String> addedMembers}) =>
+  static AppRoute scannerScreen(
+          {required List<String> addedIds, bool isForTeam = false}) =>
       AppRoute(
         pathScannerScreen,
-        builder: (_) => ScannerScreen(addedMembers: addedMembers),
+        builder: (_) => ScannerScreen(
+          addedIds: addedIds,
+          isForTeam: isForTeam,
+        ),
       );
 
   static AppRoute qrCodeView(

--- a/khelo/lib/ui/flow/team/add_team_member/add_team_member_screen.dart
+++ b/khelo/lib/ui/flow/team/add_team_member/add_team_member_screen.dart
@@ -60,9 +60,9 @@ class _AddTeamMemberScreenState extends ConsumerState<AddTeamMemberScreen> {
         actionButton(
           context,
           onPressed: () async {
-            final user = await AppRoute.scannerScreen(
-                    addedMembers: notifier.getMemberIds())
-                .push<UserModel>(context);
+            final user =
+                await AppRoute.scannerScreen(addedIds: notifier.getMemberIds())
+                    .push<UserModel>(context);
             if (context.mounted && user != null) notifier.selectUser(user);
           },
           icon: SvgPicture.asset(

--- a/khelo/lib/ui/flow/team/detail/team_detail_screen.dart
+++ b/khelo/lib/ui/flow/team/detail/team_detail_screen.dart
@@ -15,6 +15,7 @@ import 'package:khelo/ui/flow/team/detail/components/team_detail_member_content.
 import 'package:khelo/ui/flow/team/detail/team_detail_view_model.dart';
 import 'package:style/button/action_button.dart';
 import 'package:style/button/more_option_button.dart';
+import 'package:style/button/secondary_button.dart';
 import 'package:style/button/tab_button.dart';
 import 'package:style/extensions/context_extensions.dart';
 import 'package:style/indicator/progress_indicator.dart';
@@ -25,8 +26,13 @@ import 'components/team_detail_stat_content.dart';
 
 class TeamDetailScreen extends ConsumerStatefulWidget {
   final String teamId;
+  final bool showAddButton;
 
-  const TeamDetailScreen({super.key, required this.teamId});
+  const TeamDetailScreen({
+    super.key,
+    required this.teamId,
+    required this.showAddButton,
+  });
 
   @override
   ConsumerState createState() => _TeamDetailScreenState();
@@ -66,14 +72,20 @@ class _TeamDetailScreenState extends ConsumerState<TeamDetailScreen> {
             size: 24,
             color: context.colorScheme.textPrimary,
           )),
-      actions: (state.team?.isAdminOrOwner(state.currentUserId) ?? false)
-          ? [
-              moreOptionButton(
-                context,
-                onPressed: () => _moreActionButton(context, notifier, state),
-              ),
-            ]
-          : null,
+      actions: [
+        if (widget.showAddButton)
+          SecondaryButton(
+            context.l10n.common_add_title,
+            enabled: !state.loading,
+            onPressed: () => context.pop(state.team),
+          ),
+        if (!widget.showAddButton &&
+            (state.team?.isAdminOrOwner(state.currentUserId) ?? false))
+          moreOptionButton(
+            context,
+            onPressed: () => _moreActionButton(context, notifier, state),
+          ),
+      ],
       body: Builder(builder: (context) {
         return _body(context, state);
       }),

--- a/khelo/lib/ui/flow/team/scanner/scanner_screen.dart
+++ b/khelo/lib/ui/flow/team/scanner/scanner_screen.dart
@@ -51,22 +51,26 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
                 ? context.l10n.add_team_already_added
                 : context.l10n.add_team_member_already_added);
       } else if (scannedId.isNotEmpty) {
-        switch (widget.target) {
-          case ScanTarget.team:
-            final team = await AppRoute.teamDetail(
-                    teamId: scannedId, showAddButton: true)
-                .push<TeamModel>(context);
-            if (mounted) context.pop(team);
-            break;
-          case ScanTarget.player:
-            final user = await AppRoute.userDetail(
-                    userId: scannedId, showAddButton: true)
-                .push<UserModel?>(context);
-            if (mounted) context.pop(user);
-            break;
-        }
+        _handleScanTarget(widget.target, scannedId);
       }
     });
+  }
+
+  void _handleScanTarget(ScanTarget target, String scannedId) async {
+    switch (widget.target) {
+      case ScanTarget.team:
+        final team =
+            await AppRoute.teamDetail(teamId: scannedId, showAddButton: true)
+                .push<TeamModel>(context);
+        if (mounted) context.pop(team);
+        break;
+      case ScanTarget.player:
+        final user =
+            await AppRoute.userDetail(userId: scannedId, showAddButton: true)
+                .push<UserModel?>(context);
+        if (mounted) context.pop(user);
+        break;
+    }
   }
 
   void _observeError() {

--- a/khelo/lib/ui/flow/team/scanner/scanner_screen.dart
+++ b/khelo/lib/ui/flow/team/scanner/scanner_screen.dart
@@ -24,12 +24,12 @@ import '../../../../components/error_snackbar.dart';
 
 class ScannerScreen extends ConsumerStatefulWidget {
   final List<String> addedIds;
-  final bool isForTeam;
+  final ScanTarget target;
 
   const ScannerScreen({
     super.key,
     required this.addedIds,
-    this.isForTeam = false,
+    this.target = ScanTarget.player,
   });
 
   @override
@@ -47,24 +47,23 @@ class _ScannerScreenState extends ConsumerState<ScannerScreen> {
       if (widget.addedIds.contains(scannedId)) {
         showSnackBar(
             context,
-            widget.isForTeam
+            widget.target == ScanTarget.team
                 ? context.l10n.add_team_already_added
                 : context.l10n.add_team_member_already_added);
       } else if (scannedId.isNotEmpty) {
-        if (widget.isForTeam) {
-          final team =
-              await AppRoute.teamDetail(teamId: scannedId, showAddButton: true)
-                  .push<TeamModel>(context);
-          if (mounted) {
-            context.pop(team);
-          }
-        } else {
-          final user =
-              await AppRoute.userDetail(userId: scannedId, showAddButton: true)
-                  .push<UserModel?>(context);
-          if (mounted) {
-            context.pop(user);
-          }
+        switch (widget.target) {
+          case ScanTarget.team:
+            final team = await AppRoute.teamDetail(
+                    teamId: scannedId, showAddButton: true)
+                .push<TeamModel>(context);
+            if (mounted) context.pop(team);
+            break;
+          case ScanTarget.player:
+            final user = await AppRoute.userDetail(
+                    userId: scannedId, showAddButton: true)
+                .push<UserModel?>(context);
+            if (mounted) context.pop(user);
+            break;
         }
       }
     });

--- a/khelo/lib/ui/flow/team/scanner/scanner_view_model.dart
+++ b/khelo/lib/ui/flow/team/scanner/scanner_view_model.dart
@@ -15,15 +15,15 @@ final scannerStateNotifierProvider =
 });
 
 class ScannerStateNotifier extends StateNotifier<ScannerState> {
-  List<String> _addedMembers = [];
+  List<String> _addedIds = [];
   StreamSubscription? _subscription;
 
   ScannerStateNotifier() : super(const ScannerState()) {
     _checkCameraPermission();
   }
 
-  void setData(List<String> addedMembers) {
-    _addedMembers = addedMembers;
+  void setData(List<String> addedIds) {
+    _addedIds = addedIds;
   }
 
   Future<void> _checkCameraPermission() async {
@@ -62,11 +62,11 @@ class ScannerStateNotifier extends StateNotifier<ScannerState> {
     _subscription = state.controller?.scannedDataStream.listen(
       (event) {
         final code = event.code;
-        if (!_addedMembers.contains(code)) {
+        if (!_addedIds.contains(code)) {
           _removeListeners();
         }
         state = state.copyWith(
-          userId: code ?? "",
+          scannedId: code ?? "",
         );
       },
       onError: (e) {
@@ -93,7 +93,7 @@ class ScannerState with _$ScannerState {
   const factory ScannerState({
     Object? error,
     QRViewController? controller,
-    @Default('') String userId,
+    @Default('') String scannedId,
     @Default(false) bool flashOn,
     @Default(false) bool hasPermission,
   }) = _ScannerState;

--- a/khelo/lib/ui/flow/team/scanner/scanner_view_model.dart
+++ b/khelo/lib/ui/flow/team/scanner/scanner_view_model.dart
@@ -98,3 +98,5 @@ class ScannerState with _$ScannerState {
     @Default(false) bool hasPermission,
   }) = _ScannerState;
 }
+
+enum ScanTarget { player, team }

--- a/khelo/lib/ui/flow/team/scanner/scanner_view_model.freezed.dart
+++ b/khelo/lib/ui/flow/team/scanner/scanner_view_model.freezed.dart
@@ -18,7 +18,7 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$ScannerState {
   Object? get error => throw _privateConstructorUsedError;
   QRViewController? get controller => throw _privateConstructorUsedError;
-  String get userId => throw _privateConstructorUsedError;
+  String get scannedId => throw _privateConstructorUsedError;
   bool get flashOn => throw _privateConstructorUsedError;
   bool get hasPermission => throw _privateConstructorUsedError;
 
@@ -38,7 +38,7 @@ abstract class $ScannerStateCopyWith<$Res> {
   $Res call(
       {Object? error,
       QRViewController? controller,
-      String userId,
+      String scannedId,
       bool flashOn,
       bool hasPermission});
 }
@@ -60,7 +60,7 @@ class _$ScannerStateCopyWithImpl<$Res, $Val extends ScannerState>
   $Res call({
     Object? error = freezed,
     Object? controller = freezed,
-    Object? userId = null,
+    Object? scannedId = null,
     Object? flashOn = null,
     Object? hasPermission = null,
   }) {
@@ -70,9 +70,9 @@ class _$ScannerStateCopyWithImpl<$Res, $Val extends ScannerState>
           ? _value.controller
           : controller // ignore: cast_nullable_to_non_nullable
               as QRViewController?,
-      userId: null == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
+      scannedId: null == scannedId
+          ? _value.scannedId
+          : scannedId // ignore: cast_nullable_to_non_nullable
               as String,
       flashOn: null == flashOn
           ? _value.flashOn
@@ -97,7 +97,7 @@ abstract class _$$ScannerStateImplCopyWith<$Res>
   $Res call(
       {Object? error,
       QRViewController? controller,
-      String userId,
+      String scannedId,
       bool flashOn,
       bool hasPermission});
 }
@@ -117,7 +117,7 @@ class __$$ScannerStateImplCopyWithImpl<$Res>
   $Res call({
     Object? error = freezed,
     Object? controller = freezed,
-    Object? userId = null,
+    Object? scannedId = null,
     Object? flashOn = null,
     Object? hasPermission = null,
   }) {
@@ -127,9 +127,9 @@ class __$$ScannerStateImplCopyWithImpl<$Res>
           ? _value.controller
           : controller // ignore: cast_nullable_to_non_nullable
               as QRViewController?,
-      userId: null == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
+      scannedId: null == scannedId
+          ? _value.scannedId
+          : scannedId // ignore: cast_nullable_to_non_nullable
               as String,
       flashOn: null == flashOn
           ? _value.flashOn
@@ -149,7 +149,7 @@ class _$ScannerStateImpl implements _ScannerState {
   const _$ScannerStateImpl(
       {this.error,
       this.controller,
-      this.userId = '',
+      this.scannedId = '',
       this.flashOn = false,
       this.hasPermission = false});
 
@@ -159,7 +159,7 @@ class _$ScannerStateImpl implements _ScannerState {
   final QRViewController? controller;
   @override
   @JsonKey()
-  final String userId;
+  final String scannedId;
   @override
   @JsonKey()
   final bool flashOn;
@@ -169,7 +169,7 @@ class _$ScannerStateImpl implements _ScannerState {
 
   @override
   String toString() {
-    return 'ScannerState(error: $error, controller: $controller, userId: $userId, flashOn: $flashOn, hasPermission: $hasPermission)';
+    return 'ScannerState(error: $error, controller: $controller, scannedId: $scannedId, flashOn: $flashOn, hasPermission: $hasPermission)';
   }
 
   @override
@@ -180,7 +180,8 @@ class _$ScannerStateImpl implements _ScannerState {
             const DeepCollectionEquality().equals(other.error, error) &&
             (identical(other.controller, controller) ||
                 other.controller == controller) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.scannedId, scannedId) ||
+                other.scannedId == scannedId) &&
             (identical(other.flashOn, flashOn) || other.flashOn == flashOn) &&
             (identical(other.hasPermission, hasPermission) ||
                 other.hasPermission == hasPermission));
@@ -191,7 +192,7 @@ class _$ScannerStateImpl implements _ScannerState {
       runtimeType,
       const DeepCollectionEquality().hash(error),
       controller,
-      userId,
+      scannedId,
       flashOn,
       hasPermission);
 
@@ -208,7 +209,7 @@ abstract class _ScannerState implements ScannerState {
   const factory _ScannerState(
       {final Object? error,
       final QRViewController? controller,
-      final String userId,
+      final String scannedId,
       final bool flashOn,
       final bool hasPermission}) = _$ScannerStateImpl;
 
@@ -217,7 +218,7 @@ abstract class _ScannerState implements ScannerState {
   @override
   QRViewController? get controller;
   @override
-  String get userId;
+  String get scannedId;
   @override
   bool get flashOn;
   @override

--- a/khelo/lib/ui/flow/team/search_team/search_team_screen.dart
+++ b/khelo/lib/ui/flow/team/search_team/search_team_screen.dart
@@ -23,6 +23,7 @@ import 'package:style/widgets/rounded_check_box.dart';
 import '../../../../components/create_team_cell.dart';
 import '../../../../gen/assets.gen.dart';
 import '../../../app_route.dart';
+import '../scanner/scanner_view_model.dart';
 
 class SearchTeamScreen extends ConsumerStatefulWidget {
   final List<String>? excludedIds;
@@ -63,8 +64,9 @@ class _SearchTeamScreenState extends ConsumerState<SearchTeamScreen> {
           context,
           onPressed: () async {
             final team = await AppRoute.scannerScreen(
-                    isForTeam: true, addedIds: widget.excludedIds ?? [])
-                .push<TeamModel>(context);
+              target: ScanTarget.team,
+              addedIds: widget.excludedIds ?? [],
+            ).push<TeamModel>(context);
             if (context.mounted && team != null) notifier.onTeamCellTap(team);
           },
           icon: SvgPicture.asset(

--- a/khelo/lib/ui/flow/team/search_team/search_team_screen.dart
+++ b/khelo/lib/ui/flow/team/search_team/search_team_screen.dart
@@ -22,6 +22,7 @@ import 'package:style/widgets/rounded_check_box.dart';
 
 import '../../../../components/create_team_cell.dart';
 import '../../../../gen/assets.gen.dart';
+import '../../../app_route.dart';
 
 class SearchTeamScreen extends ConsumerStatefulWidget {
   final List<String>? excludedIds;
@@ -58,6 +59,22 @@ class _SearchTeamScreenState extends ConsumerState<SearchTeamScreen> {
     return AppPage(
       title: context.l10n.search_team_screen_title,
       actions: [
+        actionButton(
+          context,
+          onPressed: () async {
+            final team = await AppRoute.scannerScreen(
+                    isForTeam: true, addedIds: widget.excludedIds ?? [])
+                .push<TeamModel>(context);
+            if (context.mounted && team != null) notifier.onTeamCellTap(team);
+          },
+          icon: SvgPicture.asset(
+            Assets.images.icQrCode,
+            colorFilter: ColorFilter.mode(
+              context.colorScheme.textPrimary,
+              BlendMode.srcIn,
+            ),
+          ),
+        ),
         actionButton(
           context,
           onPressed: state.selectedTeam != null

--- a/khelo/lib/ui/flow/tournament/team_selection/team_selection_screen.dart
+++ b/khelo/lib/ui/flow/tournament/team_selection/team_selection_screen.dart
@@ -20,6 +20,7 @@ import '../../../../components/error_snackbar.dart';
 import '../../../../domain/extensions/widget_extension.dart';
 import '../../../../gen/assets.gen.dart';
 import '../../../app_route.dart';
+import '../../team/scanner/scanner_view_model.dart';
 import '../../team/search_team/components/team_member_sheet.dart';
 import 'component/team_profile_cell.dart';
 
@@ -57,10 +58,9 @@ class _TeamSelectionScreenState extends ConsumerState<TeamSelectionScreen> {
           context,
           onPressed: () async {
             final team = await AppRoute.scannerScreen(
-                    isForTeam: true,
-                    addedIds:
-                        widget.selectedTeams?.map((e) => e.id).toList() ?? [])
-                .push<TeamModel>(context);
+              target: ScanTarget.team,
+              addedIds: widget.selectedTeams?.map((e) => e.id).toList() ?? [],
+            ).push<TeamModel>(context);
             if (context.mounted && team != null) notifier.onTeamCellTap(team);
           },
           icon: SvgPicture.asset(

--- a/khelo/lib/ui/flow/tournament/team_selection/team_selection_screen.dart
+++ b/khelo/lib/ui/flow/tournament/team_selection/team_selection_screen.dart
@@ -19,6 +19,7 @@ import '../../../../components/error_screen.dart';
 import '../../../../components/error_snackbar.dart';
 import '../../../../domain/extensions/widget_extension.dart';
 import '../../../../gen/assets.gen.dart';
+import '../../../app_route.dart';
 import '../../team/search_team/components/team_member_sheet.dart';
 import 'component/team_profile_cell.dart';
 
@@ -52,6 +53,24 @@ class _TeamSelectionScreenState extends ConsumerState<TeamSelectionScreen> {
     return AppPage(
       title: context.l10n.team_selection_screen_title,
       actions: [
+        actionButton(
+          context,
+          onPressed: () async {
+            final team = await AppRoute.scannerScreen(
+                    isForTeam: true,
+                    addedIds:
+                        widget.selectedTeams?.map((e) => e.id).toList() ?? [])
+                .push<TeamModel>(context);
+            if (context.mounted && team != null) notifier.onTeamCellTap(team);
+          },
+          icon: SvgPicture.asset(
+            Assets.images.icQrCode,
+            colorFilter: ColorFilter.mode(
+              context.colorScheme.textPrimary,
+              BlendMode.srcIn,
+            ),
+          ),
+        ),
         actionButton(
           context,
           onPressed: () async {


### PR DESCRIPTION
- Select team via qr code in add match select team and tournament select teams screen.

[select team via qr code.webm](https://github.com/user-attachments/assets/cd729277-a120-4f82-b557-a77fda4f8d99)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a localized message for when a team is already added.
  - Introduced QR code scanning functionality in both the Search Team and Team Selection screens for adding teams.
  - Enhanced the Team Detail screen with an option to show an "Add Team" button based on user permissions.

- **Improvements**
  - Updated navigation methods to improve parameter handling and flexibility.
  - Refined the Scanner screen to better differentiate between team and individual member scanning.

- **Bug Fixes**
  - Improved error handling and user feedback throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->