### PR TITLE
Rename support identifier

### DIFF
--- a/data/lib/api/support/support_models.dart
+++ b/data/lib/api/support/support_models.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -13,10 +15,10 @@ class AddSupportCaseRequest with _$AddSupportCaseRequest {
     required String id,
     required String title,
     String? description,
-    @Default([]) List<String> attachmentUrls,
-    required String userId,
-    DateTime? createdAt,
-    @TimeStampJsonConverter() DateTime? createdTime,
+    @Default([]) List<String> attachment_urls,
+    required String user_id,
+    DateTime? created_at,
+    @TimeStampJsonConverter() DateTime? created_time,
   }) = _AddSupportCaseRequest;
 
   factory AddSupportCaseRequest.fromJson(Map<String, dynamic> json) =>

--- a/data/lib/api/support/support_models.freezed.dart
+++ b/data/lib/api/support/support_models.freezed.dart
@@ -24,11 +24,11 @@ mixin _$AddSupportCaseRequest {
   String get id => throw _privateConstructorUsedError;
   String get title => throw _privateConstructorUsedError;
   String? get description => throw _privateConstructorUsedError;
-  List<String> get attachmentUrls => throw _privateConstructorUsedError;
-  String get userId => throw _privateConstructorUsedError;
-  DateTime? get createdAt => throw _privateConstructorUsedError;
+  List<String> get attachment_urls => throw _privateConstructorUsedError;
+  String get user_id => throw _privateConstructorUsedError;
+  DateTime? get created_at => throw _privateConstructorUsedError;
   @TimeStampJsonConverter()
-  DateTime? get createdTime => throw _privateConstructorUsedError;
+  DateTime? get created_time => throw _privateConstructorUsedError;
 
   /// Serializes this AddSupportCaseRequest to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -50,10 +50,10 @@ abstract class $AddSupportCaseRequestCopyWith<$Res> {
       {String id,
       String title,
       String? description,
-      List<String> attachmentUrls,
-      String userId,
-      DateTime? createdAt,
-      @TimeStampJsonConverter() DateTime? createdTime});
+      List<String> attachment_urls,
+      String user_id,
+      DateTime? created_at,
+      @TimeStampJsonConverter() DateTime? created_time});
 }
 
 /// @nodoc
@@ -75,10 +75,10 @@ class _$AddSupportCaseRequestCopyWithImpl<$Res,
     Object? id = null,
     Object? title = null,
     Object? description = freezed,
-    Object? attachmentUrls = null,
-    Object? userId = null,
-    Object? createdAt = freezed,
-    Object? createdTime = freezed,
+    Object? attachment_urls = null,
+    Object? user_id = null,
+    Object? created_at = freezed,
+    Object? created_time = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -93,21 +93,21 @@ class _$AddSupportCaseRequestCopyWithImpl<$Res,
           ? _value.description
           : description // ignore: cast_nullable_to_non_nullable
               as String?,
-      attachmentUrls: null == attachmentUrls
-          ? _value.attachmentUrls
-          : attachmentUrls // ignore: cast_nullable_to_non_nullable
+      attachment_urls: null == attachment_urls
+          ? _value.attachment_urls
+          : attachment_urls // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      userId: null == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
+      user_id: null == user_id
+          ? _value.user_id
+          : user_id // ignore: cast_nullable_to_non_nullable
               as String,
-      createdAt: freezed == createdAt
-          ? _value.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
+      created_at: freezed == created_at
+          ? _value.created_at
+          : created_at // ignore: cast_nullable_to_non_nullable
               as DateTime?,
-      createdTime: freezed == createdTime
-          ? _value.createdTime
-          : createdTime // ignore: cast_nullable_to_non_nullable
+      created_time: freezed == created_time
+          ? _value.created_time
+          : created_time // ignore: cast_nullable_to_non_nullable
               as DateTime?,
     ) as $Val);
   }
@@ -126,10 +126,10 @@ abstract class _$$AddSupportCaseRequestImplCopyWith<$Res>
       {String id,
       String title,
       String? description,
-      List<String> attachmentUrls,
-      String userId,
-      DateTime? createdAt,
-      @TimeStampJsonConverter() DateTime? createdTime});
+      List<String> attachment_urls,
+      String user_id,
+      DateTime? created_at,
+      @TimeStampJsonConverter() DateTime? created_time});
 }
 
 /// @nodoc
@@ -149,10 +149,10 @@ class __$$AddSupportCaseRequestImplCopyWithImpl<$Res>
     Object? id = null,
     Object? title = null,
     Object? description = freezed,
-    Object? attachmentUrls = null,
-    Object? userId = null,
-    Object? createdAt = freezed,
-    Object? createdTime = freezed,
+    Object? attachment_urls = null,
+    Object? user_id = null,
+    Object? created_at = freezed,
+    Object? created_time = freezed,
   }) {
     return _then(_$AddSupportCaseRequestImpl(
       id: null == id
@@ -167,21 +167,21 @@ class __$$AddSupportCaseRequestImplCopyWithImpl<$Res>
           ? _value.description
           : description // ignore: cast_nullable_to_non_nullable
               as String?,
-      attachmentUrls: null == attachmentUrls
-          ? _value._attachmentUrls
-          : attachmentUrls // ignore: cast_nullable_to_non_nullable
+      attachment_urls: null == attachment_urls
+          ? _value._attachment_urls
+          : attachment_urls // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      userId: null == userId
-          ? _value.userId
-          : userId // ignore: cast_nullable_to_non_nullable
+      user_id: null == user_id
+          ? _value.user_id
+          : user_id // ignore: cast_nullable_to_non_nullable
               as String,
-      createdAt: freezed == createdAt
-          ? _value.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
+      created_at: freezed == created_at
+          ? _value.created_at
+          : created_at // ignore: cast_nullable_to_non_nullable
               as DateTime?,
-      createdTime: freezed == createdTime
-          ? _value.createdTime
-          : createdTime // ignore: cast_nullable_to_non_nullable
+      created_time: freezed == created_time
+          ? _value.created_time
+          : created_time // ignore: cast_nullable_to_non_nullable
               as DateTime?,
     ));
   }
@@ -194,11 +194,11 @@ class _$AddSupportCaseRequestImpl implements _AddSupportCaseRequest {
       {required this.id,
       required this.title,
       this.description,
-      final List<String> attachmentUrls = const [],
-      required this.userId,
-      this.createdAt,
-      @TimeStampJsonConverter() this.createdTime})
-      : _attachmentUrls = attachmentUrls;
+      final List<String> attachment_urls = const [],
+      required this.user_id,
+      this.created_at,
+      @TimeStampJsonConverter() this.created_time})
+      : _attachment_urls = attachment_urls;
 
   factory _$AddSupportCaseRequestImpl.fromJson(Map<String, dynamic> json) =>
       _$$AddSupportCaseRequestImplFromJson(json);
@@ -209,26 +209,26 @@ class _$AddSupportCaseRequestImpl implements _AddSupportCaseRequest {
   final String title;
   @override
   final String? description;
-  final List<String> _attachmentUrls;
+  final List<String> _attachment_urls;
   @override
   @JsonKey()
-  List<String> get attachmentUrls {
-    if (_attachmentUrls is EqualUnmodifiableListView) return _attachmentUrls;
+  List<String> get attachment_urls {
+    if (_attachment_urls is EqualUnmodifiableListView) return _attachment_urls;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_attachmentUrls);
+    return EqualUnmodifiableListView(_attachment_urls);
   }
 
   @override
-  final String userId;
+  final String user_id;
   @override
-  final DateTime? createdAt;
+  final DateTime? created_at;
   @override
   @TimeStampJsonConverter()
-  final DateTime? createdTime;
+  final DateTime? created_time;
 
   @override
   String toString() {
-    return 'AddSupportCaseRequest(id: $id, title: $title, description: $description, attachmentUrls: $attachmentUrls, userId: $userId, createdAt: $createdAt, createdTime: $createdTime)';
+    return 'AddSupportCaseRequest(id: $id, title: $title, description: $description, attachment_urls: $attachment_urls, user_id: $user_id, created_at: $created_at, created_time: $created_time)';
   }
 
   @override
@@ -241,12 +241,12 @@ class _$AddSupportCaseRequestImpl implements _AddSupportCaseRequest {
             (identical(other.description, description) ||
                 other.description == description) &&
             const DeepCollectionEquality()
-                .equals(other._attachmentUrls, _attachmentUrls) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.createdTime, createdTime) ||
-                other.createdTime == createdTime));
+                .equals(other._attachment_urls, _attachment_urls) &&
+            (identical(other.user_id, user_id) || other.user_id == user_id) &&
+            (identical(other.created_at, created_at) ||
+                other.created_at == created_at) &&
+            (identical(other.created_time, created_time) ||
+                other.created_time == created_time));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -256,10 +256,10 @@ class _$AddSupportCaseRequestImpl implements _AddSupportCaseRequest {
       id,
       title,
       description,
-      const DeepCollectionEquality().hash(_attachmentUrls),
-      userId,
-      createdAt,
-      createdTime);
+      const DeepCollectionEquality().hash(_attachment_urls),
+      user_id,
+      created_at,
+      created_time);
 
   /// Create a copy of AddSupportCaseRequest
   /// with the given fields replaced by the non-null parameter values.
@@ -283,10 +283,10 @@ abstract class _AddSupportCaseRequest implements AddSupportCaseRequest {
           {required final String id,
           required final String title,
           final String? description,
-          final List<String> attachmentUrls,
-          required final String userId,
-          final DateTime? createdAt,
-          @TimeStampJsonConverter() final DateTime? createdTime}) =
+          final List<String> attachment_urls,
+          required final String user_id,
+          final DateTime? created_at,
+          @TimeStampJsonConverter() final DateTime? created_time}) =
       _$AddSupportCaseRequestImpl;
 
   factory _AddSupportCaseRequest.fromJson(Map<String, dynamic> json) =
@@ -299,14 +299,14 @@ abstract class _AddSupportCaseRequest implements AddSupportCaseRequest {
   @override
   String? get description;
   @override
-  List<String> get attachmentUrls;
+  List<String> get attachment_urls;
   @override
-  String get userId;
+  String get user_id;
   @override
-  DateTime? get createdAt;
+  DateTime? get created_at;
   @override
   @TimeStampJsonConverter()
-  DateTime? get createdTime;
+  DateTime? get created_time;
 
   /// Create a copy of AddSupportCaseRequest
   /// with the given fields replaced by the non-null parameter values.

--- a/data/lib/api/support/support_models.g.dart
+++ b/data/lib/api/support/support_models.g.dart
@@ -12,16 +12,16 @@ _$AddSupportCaseRequestImpl _$$AddSupportCaseRequestImplFromJson(
       id: json['id'] as String,
       title: json['title'] as String,
       description: json['description'] as String?,
-      attachmentUrls: (json['attachmentUrls'] as List<dynamic>?)
+      attachment_urls: (json['attachment_urls'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
           const [],
-      userId: json['userId'] as String,
-      createdAt: json['createdAt'] == null
+      user_id: json['user_id'] as String,
+      created_at: json['created_at'] == null
           ? null
-          : DateTime.parse(json['createdAt'] as String),
-      createdTime: _$JsonConverterFromJson<Object, DateTime>(
-          json['createdTime'], const TimeStampJsonConverter().fromJson),
+          : DateTime.parse(json['created_at'] as String),
+      created_time: _$JsonConverterFromJson<Object, DateTime>(
+          json['created_time'], const TimeStampJsonConverter().fromJson),
     );
 
 Map<String, dynamic> _$$AddSupportCaseRequestImplToJson(
@@ -30,11 +30,11 @@ Map<String, dynamic> _$$AddSupportCaseRequestImplToJson(
       'id': instance.id,
       'title': instance.title,
       'description': instance.description,
-      'attachmentUrls': instance.attachmentUrls,
-      'userId': instance.userId,
-      'createdAt': instance.createdAt?.toIso8601String(),
-      'createdTime': _$JsonConverterToJson<Object, DateTime>(
-          instance.createdTime, const TimeStampJsonConverter().toJson),
+      'attachment_urls': instance.attachment_urls,
+      'user_id': instance.user_id,
+      'created_at': instance.created_at?.toIso8601String(),
+      'created_time': _$JsonConverterToJson<Object, DateTime>(
+          instance.created_time, const TimeStampJsonConverter().toJson),
     };
 
 Value? _$JsonConverterFromJson<Json, Value>(

--- a/khelo/lib/ui/flow/settings/support/contact_support_view_model.dart
+++ b/khelo/lib/ui/flow/settings/support/contact_support_view_model.dart
@@ -147,10 +147,10 @@ class ContactSupportViewStateNotifier
         id: _supportService.generateSupportId,
         title: state.titleController.text.trim(),
         description: state.descriptionController.text.trim(),
-        attachmentUrls: state.attachments.map((e) => e.url).nonNulls.toList(),
-        userId: _currentUserId ?? '',
-        createdAt: DateTime.now(),
-        createdTime: DateTime.now(),
+        attachment_urls: state.attachments.map((e) => e.url).nonNulls.toList(),
+        user_id: _currentUserId ?? '',
+        created_at: DateTime.now(),
+        created_time: DateTime.now(),
       );
 
       await _supportService.addSupportCase(supportCase).whenComplete(


### PR DESCRIPTION
Rename support identifier to use snake_case to match other firestore fields format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated naming conventions for support case fields to snake_case for consistency across the application.

- **Bug Fixes**
	- Ensured proper serialization and deserialization of support case fields in line with the new naming conventions.

- **Documentation**
	- Clarified the structure and naming conventions in the support case submission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->